### PR TITLE
Changes for v0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,16 @@ Here is an example of the sample sheet:
 | sample_id | fastq_pattern | genome_id | bc1 | bc2 | bc3 | adapter_read1_3prime | adapter_read2_3prime | adapter_read1_5prime | adapter_read2_5prime | umi_read1 | umi_read2 |
 | --------- | ------------- | --------- | --- | --- | --- | ------------- | --------- | --------- | --------- | --------- | ------------- |
 | EcoHX1 | G5512A22_R | GCF_904425475.1 | bc1.csv | bc2.csv | bc3.csv | CAGN{6}G{3} | N{7}N{8}TTATTATA | TATAATAAN{8}N{7} | C{3}N{6}CTG | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
-| EcoHX2 | G5512A23_R | GCF_904425475.1 | CAGN{6}G{3} | N{7}N{8}TTATTATA | TATAATAAN{8}N{7} | C{3}N{6}CTG | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
+| EcoHX2 | G5512A23_R | GCF_904425475.1 | bc1.csv | bc2.csv | bc3.csv | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
+
+And here is an example barcode file:
+
+| Barcode ID | Sequence |
+| ---------- | -------- |
+| barcode-01 | ATCGATCC |
+| barcode-02 | TAGCTAGG |
+
+It must have a header row and two columns, with the second column being the barcode sequence.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Each time you run the pipeline after the first time, Nextflow will use a locally
 the pipeline, use the `-r <version>` flag. For example,
 
 ```bash 
-nextflow run scbirlab/nf-sbrnaseq -r v0.0.1
+nextflow run scbirlab/nf-sbrnaseq -r v0.0.4
 ```
 
 A list of versions can be found by running `nextflow info scbirlab/nf-sbrnaseq`.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ For each sample:
 4. Deduplicate mapped reads using `umitools`.
 5. Count deduplicated reads per gene using `featureCounts`.
 6. Count deduplicated reads per gene per cell using `umi-tools`.
+7. Plot:
+    - Histogram of UMIs per cell per gene
+    - Histogram of unique genes per cell
+    - Histogram of unique cells per gene
+    - Scatter of UMI count vs gene count
+    - Scatter of UMI count vs cell count
+8. Use `scanpy` to filter cells to have > 20 unique genes, and filter genes to be found in > 0 cells, run basic QC, Leiden cluster and UMAP embed with default settings, and save resulting plots and AnnData object as `.h5ad` for downstream analysis.  
 
 ### Downstream analyses [work in progress, not yet implemented]
 
@@ -133,6 +140,7 @@ The file must have a header with the column names below, and one line per sample
 - `sample_id`: the unique name of the sample
 - `genome_id`: The [NCBI assembly accession](https://www.ncbi.nlm.nih.gov/datasets/genome/) number for the organism that the guide RNAs are targeting. This number starts with "GCF_" or "GCA_".
 - `fastq_pattern`: the search glob to find FASTQ files for each sample in `fastq_dir`. The pipleine will look for files matching `<fastq_dir>/*<fastq_pattern>*`, and should match only two files, corresponding to paired reads.
+- `bc1`, `bc2`, `bc3`: Files containg barcodes corresponding to `<cell_1>`, `<cell_2>`, and `<cell_3>` in `umi_read*` columns.
 - `adapter_read1_3prime`: the 3' adapter on the forward read to trim to in [`cutadapt` format](https://cutadapt.readthedocs.io/en/stable/guide.html#specifying-adapter-sequences). The adapter itself and sequences downstream will be removed.
 - `adapter_read2_3prime`:  the 3' adapter on the reverse read to trim to in [`cutadapt` format](https://cutadapt.readthedocs.io/en/stable/guide.html#specifying-adapter-sequences). The adapter itself and sequences downstream will be removed.
 - `adapter_read1_5prime`: the 5' adapter on the forward read to trim to in [`cutadapt` format](https://cutadapt.readthedocs.io/en/stable/guide.html#specifying-adapter-sequences). Sequences _upstream_ will be removed, but the adapters themselves will be retained.
@@ -142,9 +150,9 @@ The file must have a header with the column names below, and one line per sample
 
 Here is an example of the sample sheet:
 
-| sample_id | fastq_pattern | genome_id | adapter_read1_3prime | adapter_read2_3prime | adapter_read1_5prime | adapter_read2_5prime | umi_read1 | umi_read2 |
-| --------- | --------- | ------------- | ------------- | --------- | --------- | --------- | --------- | ------------- |
-| EcoHX1 | G5512A22_R | GCF_904425475.1 | CAGN{6}G{3} | N{7}N{8}TTATTATA | TATAATAAN{8}N{7} | C{3}N{6}CTG | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
+| sample_id | fastq_pattern | genome_id | bc1 | bc2 | bc3 | adapter_read1_3prime | adapter_read2_3prime | adapter_read1_5prime | adapter_read2_5prime | umi_read1 | umi_read2 |
+| --------- | ------------- | --------- | --- | --- | --- | ------------- | --------- | --------- | --------- | --------- | ------------- |
+| EcoHX1 | G5512A22_R | GCF_904425475.1 | bc1.csv | bc2.csv | bc3.csv | CAGN{6}G{3} | N{7}N{8}TTATTATA | TATAATAAN{8}N{7} | C{3}N{6}CTG | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
 | EcoHX2 | G5512A23_R | GCF_904425475.1 | CAGN{6}G{3} | N{7}N{8}TTATTATA | TATAATAAN{8}N{7} | C{3}N{6}CTG | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -4,14 +4,29 @@ Nextflow pipeline to process *already demultiplexed* Illumina paired-end FASTQ f
 
 ## Processing steps
 
-Per sample:
+For each set of barcodes:
+
+1. Generate all combinations to make a cell barcode whitelist.
+2. For each cell barcode, generate all 1-error variants for parsing by `umi-tools`.
+
+For each reference genome:
+
+1. Download the genome FASTA and GFF.
+
+For each sample:
 
 1. Trim reads to adapters using `cutadapt`. Reads from sbRNA-seq will be flanked by sequences containing cell barcodes and UMIs, so this step trims any extra sequences either side of these flanking sequences.
-2. Extract cell barcodes and UMIs using `umitools`.
+2. Extract cell barcodes and UMIs using `umi-tools`.
 3. Map to genome FASTA using `bowtie2`.
 4. Deduplicate mapped reads using `umitools`.
 5. Count deduplicated reads per gene using `featureCounts`.
-6. Count deduplicated reads per gene per cell using `umitools`.
+6. Count deduplicated reads per gene per cell using `umi-tools`.
+
+### Downstream analyses [work in progress, not yet implemented]
+
+1. De novo transcriptome assembly with Trinity.
+2. Isoform analysis with RSEM.
+3. Plotting and visualisation.
 
 ### Other steps
 
@@ -22,16 +37,7 @@ Per sample:
 
 ### Software
 
-You need to have Nextflow and either `conda` or `mamba` installed on your system. If possible, use `mamba` because it will be faster.
-
-### Reference genome and genome annotations
-
-You also need the genome FASTA and GFF annotations for the bacteria you are sequencing. These can be obtained from [NCBI Nucleotide](https://www.ncbi.nlm.nih.gov/nuccore/):
-
-1. Search for your strain of interest, and open its main page
-2. On the right-hand side, click `Customize view`, then `Customize` and check `Show sequence`. Finally, click `Update view`. You may have to wait a few minute while the sequence downloads.
-3. Click `Send to: > Complete record > File > [FASTA or GFF3] > Create file`
-4. Save the files to directories which you provide as parameters below.
+You need to have Nextflow and `conda` installed on your system.
 
 ### First time using Nextflow?
 
@@ -64,11 +70,14 @@ Make a [sample sheet (see below)](#sample-sheet)  and, optionally, a [`nextflow.
 nextflow run scbirlab/nf-sbrnaseq
 ```
 
-Each time you run the pipeline after the first time, Nextflow will use a locally-cached version which will not be automatically updated. If you want to ensure that you're using the very latest version of the pipeline, use the `-latest` flag.
+Each time you run the pipeline after the first time, Nextflow will use a locally-cached version which will not be automatically updated.  If you want to ensure that you're running a version of 
+the pipeline, use the `-r <version>` flag. For example,
 
 ```bash 
-nextflow run scbirlab/nf-sbrnaseq -latest
+nextflow run scbirlab/nf-sbrnaseq -r v0.0.1
 ```
+
+A list of versions can be found by running `nextflow info scbirlab/nf-sbrnaseq`.
 
 For help, use `nextflow run scbirlab/nf-sbrnaseq --help`.
 
@@ -80,14 +89,13 @@ The following parameters are required:
 
 - `sample_sheet`: path to a CSV containing sample IDs matched with FASTQ filenames, genome information, and adapter sequences.
 - `fastq_dir`: path to directory containing the FASTQ files
-- `genome_fasta_dir`: path to directory containing genome FASTA files (for mapping)
-- `genome_gff_dir`: path to directory containing genome GFF files (for feature counting)
 
 The following parameters have default values can be overridden if necessary.
 
-- `trim_qual = 10` : For `cutadapt`, the minimum Phred score for trimming 3' calls
-- `min_length = 11` : For `cutadapt`, the minimum trimmed length of a read. Shorter reads will be discarded
-- `umitools_error = 6`: For `umitools`, the number of errors allowed to correct cell barcodes
+- `inputs = "inputs"`: path to directory containing files referenced in the `sample_sheet`, such as lists of guide RNAs.
+- `output = "outputs"`: path to directory to put output files 
+- `trim_qual = 5` : For `cutadapt`, the minimum Phred score for trimming 3' calls
+- `min_length = "9:38"` : For `cutadapt`, the minimum trimmed length of a read. Shorter reads will be discarded
 - `strand = 1` : For `featureCounts`, the strandedness of RNA-seq. `1` for forward, `2` for reverse.
 - `ann_type = 'gene'` : For `featureCounts`, features from GFF column 3 to use for counting
 - `label = 'Name'` : For `featureCounts`, one or more (comma-separated) fields from column 9 of GFF for labeling counts
@@ -102,8 +110,7 @@ params {
     sample_sheet = "/path/to/sample_sheet.csv"
     fastq_dir = "/path/to/fastqs"
 
-    genome_fasta_dir = "/path/to/fastas"
-    genome_gff_dir = "/path/to/gffs"
+    trim_qual = 15
 }
 ```
 
@@ -113,19 +120,19 @@ Alternatively, you can provide these on the command line:
 nextflow run scbirlab/nf-sbrnaseq \
     --sample_sheet /path/to/sample_sheet.csv \
     --fastq_dir /path/to/fastqs \
-    --genome_fasta_dir /path/to/fastas \
-    --genome_gff_dir /path/to/gffs
+    --trim_qual 15
 ``` 
 
 ### Sample sheet
 
-The sample sheet is a CSV file providing information about which demultiplexed FASTQ files belong to which sample, which genome each sample should be mapped to, and the UMI and cell barcode scheme for each sample.
+The sample sheet is a CSV file providing information about each sample: which FASTQ files belong 
+to it, the reference genome accession number, adapters to be trimmed off, and the UMI and cell barcode scheme for each sample.
 
 The file must have a header with the column names below, and one line per sample to be processed.
 
 - `sample_id`: the unique name of the sample
+- `genome_id`: The [NCBI assembly accession](https://www.ncbi.nlm.nih.gov/datasets/genome/) number for the organism that the guide RNAs are targeting. This number starts with "GCF_" or "GCA_".
 - `fastq_pattern`: the search glob to find FASTQ files for each sample in `fastq_dir`. The pipleine will look for files matching `<fastq_dir>/*<fastq_pattern>*`, and should match only two files, corresponding to paired reads.
-- `genome_id`: the name of the genome to map to. Each entry must match the name of one file (apart from the extension) in `genome_fasta_dir` and `genome_gff_dir`
 - `adapter_read1_3prime`: the 3' adapter on the forward read to trim to in [`cutadapt` format](https://cutadapt.readthedocs.io/en/stable/guide.html#specifying-adapter-sequences). The adapter itself and sequences downstream will be removed.
 - `adapter_read2_3prime`:  the 3' adapter on the reverse read to trim to in [`cutadapt` format](https://cutadapt.readthedocs.io/en/stable/guide.html#specifying-adapter-sequences). The adapter itself and sequences downstream will be removed.
 - `adapter_read1_5prime`: the 5' adapter on the forward read to trim to in [`cutadapt` format](https://cutadapt.readthedocs.io/en/stable/guide.html#specifying-adapter-sequences). Sequences _upstream_ will be removed, but the adapters themselves will be retained.
@@ -137,8 +144,8 @@ Here is an example of the sample sheet:
 
 | sample_id | fastq_pattern | genome_id | adapter_read1_3prime | adapter_read2_3prime | adapter_read1_5prime | adapter_read2_5prime | umi_read1 | umi_read2 |
 | --------- | --------- | ------------- | ------------- | --------- | --------- | --------- | --------- | ------------- |
-| EcoHX1 | G5512A22_R | EcoMG1655-NC_000913.3 | CAGN{6}G{3};e=1 | N{7}N{8}TTATTATA | TATAATAAN{8}N{7} | C{3}N{6}CTG | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
-| EcoHX2 | G5512A23_R | EcoMG1655-NC_000913.3 | CAGN{6}G{3};e=1 | N{7}N{8}TTATTATA | TATAATAAN{8}N{7} | C{3}N{6}CTG | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
+| EcoHX1 | G5512A22_R | GCF_904425475.1 | CAGN{6}G{3} | N{7}N{8}TTATTATA | TATAATAAN{8}N{7} | C{3}N{6}CTG | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
+| EcoHX2 | G5512A23_R | GCF_904425475.1 | CAGN{6}G{3} | N{7}N{8}TTATTATA | TATAATAAN{8}N{7} | C{3}N{6}CTG | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,14 @@ The first time you run the pipeline on your system, the software dependencies in
 The following parameters are required:
 
 - `sample_sheet`: path to a CSV containing sample IDs matched with FASTQ filenames, genome information, and adapter sequences.
+
+If you're using local FASTQ data (the default, `from_sra = false`), you also need to supply the parameter:
 - `fastq_dir`: path to directory containing the FASTQ files
 
 The following parameters have default values can be overridden if necessary.
 
+- `from_sra = false`: whether to fetch FASTQ files from an SRA Run ID instead of loading local files. In this case, your sample sheet needs a column headed `Run` to indicate the Run ID.
+- `allow_cell_errors = true`: Whether to allow 1 error when matching cell barcodes in the whitelist. Otherwise only exact matches are allowed. This is ignored when the total length of the cell barcode is too long.
 - `inputs = "inputs"`: path to directory containing files referenced in the `sample_sheet`, such as lists of guide RNAs.
 - `output = "outputs"`: path to directory to put output files 
 - `trim_qual = 5` : For `cutadapt`, the minimum Phred score for trimming 3' calls
@@ -139,7 +143,14 @@ The file must have a header with the column names below, and one line per sample
 
 - `sample_id`: the unique name of the sample
 - `genome_id`: The [NCBI assembly accession](https://www.ncbi.nlm.nih.gov/datasets/genome/) number for the organism that the guide RNAs are targeting. This number starts with "GCF_" or "GCA_".
+
+If using local files (`from_sra = false`):
 - `fastq_pattern`: the search glob to find FASTQ files for each sample in `fastq_dir`. The pipleine will look for files matching `<fastq_dir>/*<fastq_pattern>*`, and should match only two files, corresponding to paired reads.
+
+If using SRA files (`from_sra = false`):
+- `Run`: the SRA run ID of this sample. When using SRA-derived FASTQ files, the **Illumina indices will be prepended** to the read, so you will have to account for this in your `adapter_read*` columns and `umi_read*` columns
+
+Other required columns:
 - `bc1`, `bc2`, `bc3`: Files containg barcodes corresponding to `<cell_1>`, `<cell_2>`, and `<cell_3>` in `umi_read*` columns.
 - `adapter_read1_3prime`: the 3' adapter on the forward read to trim to in [`cutadapt` format](https://cutadapt.readthedocs.io/en/stable/guide.html#specifying-adapter-sequences). The adapter itself and sequences downstream will be removed.
 - `adapter_read2_3prime`:  the 3' adapter on the reverse read to trim to in [`cutadapt` format](https://cutadapt.readthedocs.io/en/stable/guide.html#specifying-adapter-sequences). The adapter itself and sequences downstream will be removed.
@@ -153,7 +164,7 @@ Here is an example of the sample sheet:
 | sample_id | fastq_pattern | genome_id | bc1 | bc2 | bc3 | adapter_read1_3prime | adapter_read2_3prime | adapter_read1_5prime | adapter_read2_5prime | umi_read1 | umi_read2 |
 | --------- | ------------- | --------- | --- | --- | --- | ------------- | --------- | --------- | --------- | --------- | ------------- |
 | EcoHX1 | G5512A22_R | GCF_904425475.1 | bc1.csv | bc2.csv | bc3.csv | CAGN{6}G{3} | N{7}N{8}TTATTATA | TATAATAAN{8}N{7} | C{3}N{6}CTG | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
-| EcoHX2 | G5512A23_R | GCF_904425475.1 | bc1.csv | bc2.csv | bc3.csv | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
+| EcoHX2 | G5512A23_R | GCF_904425475.1 | bc1.csv | bc2.csv | bc3.csv | CAGN{6}G{3} | N{7}N{8}TTATTATA | TATAATAAN{8}N{7} | C{3}N{6}CTG | ^(?P<discard_1>.{3})(?P<cell_1>.{6}).* | ^(?P<discard_2>.{8})(?P<cell_2>.{8})(?P<umi_1>.{7}).* |
 
 And here is an example barcode file:
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
     - bioconda
 
 dependencies:
-    - python>=3.8
+    - python>=3.12
     - pip
     - bioconda::bowtie2
     - bioconda::fastqc
@@ -17,4 +17,4 @@ dependencies:
         - 'multiqc>=1.21'
         - numpy
         - pandas
-        - 'umi_tools>=1.0'
+        - 'umi_tools>=1.1.6'

--- a/environment.yml
+++ b/environment.yml
@@ -12,9 +12,12 @@ dependencies:
     - bioconda::samtools
     - bioconda::subread
     - pip:
+        - anndata
+        - 'carabiner-tools[mpl,pd]>=0.0.3.post1'
         - 'cutadapt>=4.0'
         - matplotlib
         - 'multiqc>=1.21'
         - numpy
         - pandas
+        - 'scanpy[leiden]'
         - 'umi_tools>=1.1.6'

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
     - bioconda::bowtie2
     - bioconda::fastqc
     - bioconda::samtools
+    - bioconda::sra-tools
     - bioconda::subread
     - pip:
         - anndata

--- a/main.nf
+++ b/main.nf
@@ -217,8 +217,8 @@ workflow {
       .combine( genome_gff, by: 0 )  // sample_id, dedup_bam, gff
       | FEATURECOUNTS  // sample_id, [count_bam_bai]
 
-   // FEATURECOUNTS.out.main
-   //    | UMITOOLS_COUNT   // sample_id, counts
+   FEATURECOUNTS.out.main
+      | UMITOOLS_COUNT   // sample_id, counts
 
    TRIM_CUTADAPT.out.logs
       .concat(
@@ -696,14 +696,16 @@ process UMITOOLS_COUNT {
 
    script:
    """
-   samtools index ${bamfile}
+   samtools sort ${bamfile} -o ${bamfile.getBaseName()}.sorted.bam
+   samtools index ${bamfile.getBaseName()}.sorted.bam
    umi_tools count \
 		--per-gene \
       --per-cell \
 		--gene-tag XT \
       --log ${sample_id}.count.log \
-		--stdin ${bamfile} \
+		--stdin ${bamfile.getBaseName()}.sorted.bam \
       --stdout ${sample_id}.umitools_count.tsv
+   rm ${bamfile.getBaseName()}.sorted.bam
    """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -10,6 +10,11 @@
 */
 
 nextflow.enable.dsl=2
+pipeline_title = """\
+                 S C B I R   s b R N A - S E Q   P I P E L I N E
+                 ===============================================
+                 """
+                 .stripIndent()
 
 /*
 ========================================================================================
@@ -17,27 +22,22 @@ nextflow.enable.dsl=2
 ========================================================================================
 */
 if ( params.help ) {
-   println """\
-         S C B I R   s b R N A - S E Q   P I P E L I N E
-         ===============================================
+   println pipeline_title + """\
          Nextflow pipeline to process demultiplexed Illumina paired-end 
          FASTQ files from multiple bacterial samples into a gene x
          cell count table.
 
          Usage:
-            nextflow run sbcirlab/nf-sbrnaseq --sample_sheet <csv> --fastq_dir <dir> --genome_fasta_dir <dir> --genome_gff_dir <dir>
+            nextflow run sbcirlab/nf-sbrnaseq --sample_sheet <csv> --fastq-dir <dir>
             nextflow run sbcirlab/nf-sbrnaseq -c <config-file>
 
          Required parameters:
             sample_sheet         Path to a CSV containing sample IDs matched with FASTQ filenames, genome information, and adapter sequences.
             fastq_dir            Path to directory containing the FASTQ file.
-            genome_fasta_dir     Path to directory containing genome FASTA files (for mapping)
-            genome_gff_dir       Path to directory containing genome GFF files (for feature counting)
 
          Optional parameters (with defaults):   
-            trim_qual = 10       For `cutadapt`, the minimum Phred score for trimming 3' calls
-            min_length = 11      For `cutadapt`, the minimum trimmed length of a read. Shorter reads will be discarded
-            umitools_error = 6   For `umitools`, the number of errors allowed to correct cell barcodes
+            trim_qual = 5        For `cutadapt`, the minimum Phred score for trimming 3' calls
+            min_length = "9:38"  For `cutadapt`, the minimum trimmed length of a read. Shorter reads will be discarded
             strand = 1           For `featureCounts`, the strandedness of RNA-seq. `1` for forward, `2` for reverse.
             ann_type = 'gene'    For `featureCounts`, features from GFF column 3 to use for counting
             label = 'Name'       For `featureCounts`, one or more (comma-separated) fields from column 9 of GFF for labeling counts
@@ -59,79 +59,39 @@ if ( !params.sample_sheet ) {
 if ( !params.fastq_dir ) {
    throw new Exception("!!! PARAMETER MISSING: Please provide a path to fastq_dir")
 }
-if ( !params.genome_fasta_dir ) {
-   throw new Exception("!!! PARAMETER MISSING: Please provide a path to genome_fasta_dir")
-}
-if ( !params.genome_gff_dir ) {
-   throw new Exception("!!! PARAMETER MISSING: Please provide a path to genome_gff_dir")
-}
 
-wd = file(params.sample_sheet)
-working_dir = wd.getParent()
+working_dir = params.outputs
 
-processed_o = "${working_dir}/outputs/processed"
-counts_o = "${working_dir}/outputs/counts"
-multiqc_o = "${working_dir}/outputs/multi_qc"
+processed_o = "${working_dir}/processed"
+counts_o = "${working_dir}/counts"
+multiqc_o = "${working_dir}/multi_qc"
 
-log.info """\
-         S C B I R   s b R N A - S E Q   P I P E L I N E
-         ===============================================
-         inputs
-            sample sheet   : ${params.sample_sheet}
-            fastq directory: ${params.fastq_dir}
-         genome locations
-            FASTA          : ${params.genome_fasta_dir}
-            GFF            : ${params.genome_gff_dir}
-         trimming 
-            quality        : ${params.trim_qual}
-            minimum length : ${params.min_length}
-         UMI detection
-            Error number   : ${params.umitools_error}
-         output            
-            Processed      : ${processed_o}
-            Counts         : ${counts_o}
-            MultiQC        : ${multiqc_o}
-         """
-         .stripIndent()
+log.info pipeline_title + """\
+   inputs
+      input dir.     : ${params.inputs}
+      FASTQ dir.     : ${params.fastq_dir}
+      sample sheet   : ${params.sample_sheet}
+   trimming 
+      quality        : ${params.trim_qual}
+      minimum length : ${params.min_length}
+   output            
+      Processed      : ${processed_o}
+      Counts         : ${counts_o}
+      MultiQC        : ${multiqc_o}
+   """
+   .stripIndent()
 
 dirs_to_make = [processed_o, counts_o, multiqc_o]
 
-log.info  """
-         Making directories: 
-          """.stripIndent()
+log.info  """\
+          Making directories: 
+          """
+          .stripIndent()
 
 dirs_to_make.each { 
    log.info "${it}: " 
    log.info file(it).mkdirs() ? "OK" : "Cannot create directory: ${it}"
 }
-
-/*
-========================================================================================
-   Create Channels
-========================================================================================
-*/
-
-csv_ch = Channel.fromPath( params.sample_sheet, 
-                           checkIfExists: true )
-               .splitCsv( header: true )
-
-sample_ch = csv_ch.map { tuple( it.genome_id,
-                                it.sample_id, 
-                                tuple( it.adapter_read1_3prime,
-                                       it.adapter_read2_3prime,
-                                       it.adapter_read1_5prime,
-                                       it.adapter_read2_5prime ),
-                                tuple( it.umi_read1, 
-                                       it.umi_read2 ),
-                                file( "${params.fastq_dir}/*${it.fastq_pattern}*",
-                                      checkIfExists: true ).sort() ) }
-
-genome_ch = csv_ch.map { tuple( it.genome_id,
-                                file( "${params.genome_fasta_dir}/${it.genome_id}.fasta",
-                                      checkIfExists: true),
-                                file( "${params.genome_gff_dir}/${it.genome_id}.gff3",
-                                      checkIfExists: true) ) }
-                  .unique()
 
 /*
 ========================================================================================
@@ -141,58 +101,201 @@ genome_ch = csv_ch.map { tuple( it.genome_id,
 
 workflow {
 
-   sample_ch | FASTQC 
+   Channel.of( params.umicollapse_repo )
+   | DOWNLOAD_UMICOLLAPSE
 
-   sample_ch | TRIM_CUTADAPT 
-   TRIM_CUTADAPT.out.main | UMITOOLS_WHITELIST
-   // TRIM_CUTADAPT.out.main.join( UMITOOLS_WHITELIST.out.main, 
-   //                              by: 1 ) | UMITOOLS_EXTRACT
-   TRIM_CUTADAPT.out.main | UMITOOLS_EXTRACT
+   Channel.fromPath( 
+         params.sample_sheet, 
+         checkIfExists: true 
+      )
+      .splitCsv( header: true )
+      .set { csv_ch }
+   csv_ch
+      .map { tuple( 
+         it.sample_id,
+         tuple( it.adapter_read1_5prime, it.adapter_read2_5prime ),
+         tuple( it.adapter_read1_3prime, it.adapter_read2_3prime ) 
+      ) }
+      .set { adapter_ch }  // sample_name, [adapt5], [adapt3] 
+   csv_ch
+      .map { tuple( 
+         it.sample_id,
+         tuple( it.umi_read1, it.umi_read2 )
+      ) }
+      .set { umi_ch }  // sample_id, [umis]
+   csv_ch
+      .map { tuple( 
+         it.sample_id,
+         tuple( 
+            it.bc1, 
+            it.bc2, 
+            it.bc3
+         ).collect {
+            file( 
+               "${params.inputs}/${it}",
+               checkIfExists: true 
+            )
+         }
+      ) }
+      .map { tuple(
+         it[0], 
+         it[1].collect { x -> x.getSimpleName() }.join("-"),
+         it[1]
+      ) }
+      .set { barcode_ch }  // sample_id, wl_id, [BCs]
+   csv_ch
+      .map { tuple( 
+         it.sample_id,
+         file( 
+            "${params.fastq_dir}/*${it.fastq_pattern}*",
+             checkIfExists: true 
+         ).sort()
+      ) }
+      .set { reads_ch }  // sample_id, [reads]
+   csv_ch
+      .map { tuple( 
+         it.sample_id,
+         it.genome_accession 
+      ) }
+      .set { genome_ch }  // sample_id, genome_acc
 
-   genome_ch | BOWTIE2_INDEX 
+   genome_ch
+      .map { it[1] }  // genome_acc
+      .unique()
+      | DOWNLOAD_GENOME   // genome_acc, genome, gff
+   DOWNLOAD_GENOME.out
+      .map { it[0..1] }  // genome_acc, genome
+      | BOWTIE2_INDEX   // genome_acc, [genome_idx]
+   genome_ch
+      .map { it[1..0] }  // genome_acc, sample_id
+      .combine( BOWTIE2_INDEX.out, by: 0 )  // genome_acc, sample_id, [genome_idx]
+      .map { it[1..-1] + [ it[0] ] }  // sample_id, [genome_idx], genome_acc
+      .set { genome_idx }
+   genome_ch
+      .map { it[1..0] }  // genome_acc, sample_id
+      .combine( DOWNLOAD_GENOME.out, by: 0 )  // genome_acc, sample_id, genome, gff
+      .map { tuple( it[1], it[-1] ) }  // sample_id, gff
+      .set { genome_gff }
+   
+   reads_ch | FASTQC 
 
-   UMITOOLS_EXTRACT.out.main.combine( BOWTIE2_INDEX.out, 
-                                      by: 0 ) | BOWTIE2_ALIGN
+   Channel.value( 
+      tuple( params.trim_qual, params.min_length )
+   ).set { trim_params } 
+   TRIM_CUTADAPT(
+      reads_ch.combine( adapter_ch, by: 0 ),  // sample_id, [reads], [adapt5], [adapt3]
+      trim_params
+   )  // sample_id, [reads]
+   barcode_ch
+      .map { it[1..2] }  // wl_id, [BCs]
+      .unique()
+      | BUILD_WHITELIST  // wl_id, whitelist
+      | ADD_WHITELIST_ERRORS // wl_id, whitelist_err
+   barcode_ch
+      .map { it[1..0] }  // wl_id, sample_id
+      .combine( ADD_WHITELIST_ERRORS.out, by: 0 )  // wl_id, sample_id, whitelist_err
+      .map { it[1..-1] }  // sample_id, whitelist_err
+      .set { whitelists }
+   // TRIM_CUTADAPT.out.main | UMITOOLS_WHITELIST
+   TRIM_CUTADAPT.out.main  // sample_id, [reads]
+      .combine( umi_ch, by: 0 )  // sample_id, [reads], umis
+      .combine( whitelists, by: 0 )  // sample_id, [reads], umis, whitelist
+      | UMITOOLS_EXTRACT  // sample_id, [reads]
 
-   BOWTIE2_ALIGN.out.main \
-      | UMITOOLS_DEDUP
+   UMITOOLS_EXTRACT.out.main
+      .combine( genome_idx, by: 0 )  // sample_id, [reads], [genome_idx], genome_acc
+      | BOWTIE2_ALIGN  // sample_id, [bam_bai]
 
-   UMITOOLS_DEDUP.out.main \
-      | FEATURECOUNTS
+   // BOWTIE2_ALIGN.out.main
+   //    | UMITOOLS_DEDUP  // sample_id, dedup_bam
 
-   FEATURECOUNTS.out.main \
-      | UMITOOLS_COUNT 
+   BOWTIE2_ALIGN.out.main
+      .combine( DOWNLOAD_UMICOLLAPSE.out )  // sample_id, [bam_bai], umicollapse_repo
+      | UMICOLLAPSE  // sample_id, dedup_bam
 
-   TRIM_CUTADAPT.out.logs.concat(
-         FASTQC.out.logs,
+   UMICOLLAPSE.out.main
+      .combine( genome_gff, by: 0 )  // sample_id, dedup_bam, gff
+      | FEATURECOUNTS  // sample_id, [count_bam_bai]
+
+   // FEATURECOUNTS.out.main
+   //    | UMITOOLS_COUNT   // sample_id, counts
+
+   TRIM_CUTADAPT.out.logs
+      .concat(
+         FASTQC.out.multiqc_logs,
          BOWTIE2_ALIGN.out.logs,
-         FEATURECOUNTS.out.logs )
+         FEATURECOUNTS.out.logs 
+      )
       .flatten()
       .unique()
-      .collect() \
+      .collect()
       | MULTIQC
 
 }
 
-/* 
- * Do quality control checks
- */
-process FASTQC {
-
-   memory '32GB'
-
-   tag "${sample_id}" 
+process DOWNLOAD_UMICOLLAPSE {
 
    input:
-   tuple val( genome_id ), val( sample_id ), val( adapters ), val( umis ), path( 'reads_*' )
+   val umicollapse_repo
 
    output:
-   path( "*.zip" ), emit: logs
+   path "UMICollapse"
 
    script:
    """
-   zcat reads_* > ${sample_id}.fastq
-   fastqc --noextract --memory 10000 --threads 4 ${sample_id}.fastq
+   git clone ${umicollapse_repo} #https://github.com/siddharthab/UMICollapse.git
+   UMI_LIB_PATH=UMICollapse/lib
+   mkdir -p \$UMI_LIB_PATH
+   curl -L https://repo1.maven.org/maven2/com/github/samtools/htsjdk/2.19.0/htsjdk-2.19.0.jar > \$UMI_LIB_PATH/htsjdk-2.19.0.jar
+   curl -L https://repo1.maven.org/maven2/org/xerial/snappy/snappy-java/1.1.7.3/snappy-java-1.1.7.3.jar > \$UMI_LIB_PATH/snappy-java-1.1.7.3.jar
+   """
+
+
+}
+
+process DOWNLOAD_GENOME {
+
+   tag "${accession}"
+   label 'some_mem'
+
+   input:
+   val accession
+
+   output:
+   tuple val( accession ), path( "ncbi_dataset/data/*/${accession}_*_genomic.fna" ), path( "ncbi_dataset/data/*/*.gff" )
+
+   script:
+   """
+   wget "https://api.ncbi.nlm.nih.gov/datasets/v2alpha/genome/accession/${accession}/download?include_annotation_type=GENOME_FASTA&include_annotation_type=GENOME_GFF&include_annotation_type=SEQUENCE_REPORT&hydrated=FULLY_HYDRATED" -O genome-out
+   unzip -o genome-out ncbi_dataset/data/${accession}/{${accession}_*_genomic.fna,*.gff}
+   """
+}
+
+
+// Do quality control checks
+process FASTQC {
+
+   label 'med_mem'
+
+   tag "${sample_id}"
+
+   input:
+   tuple val( sample_id ), path ( reads )
+
+   output:
+   tuple val( sample_id ), path ( "*.zip" ), emit: logs
+   path "*.zip", emit: multiqc_logs
+
+   script:
+   """
+   zcat ${reads} > ${sample_id}.fastq
+   fastqc --noextract --memory 10000 --threads ${task.cpus} ${sample_id}.fastq
+   rm ${sample_id}.fastq
+   """
+   stub:
+   """
+   zcat ${reads} | head -n1000 > ${sample_id}.fastq
+   fastqc --noextract --memory 10000 --threads ${task.cpus} ${sample_id}.fastq
    rm ${sample_id}.fastq
    """
 
@@ -204,18 +307,23 @@ process FASTQC {
 process TRIM_CUTADAPT {
 
    tag "${sample_id}"
+   
+   errorStrategy 'retry'
+   maxRetries 2
 
    publishDir( processed_o, 
                mode: 'copy' )
 
    input:
-   tuple val( genome_id ), val( sample_id ), val( adapters ), val( umis ), path( reads, stageAs: "?/*" )
+   tuple val( sample_id ), path( reads, stageAs: "?/*" ), val( adapters5 ), val( adapters3 )
+   tuple val( trim_qual ), val( min_length )
 
    output:
-   tuple val( genome_id ), val( sample_id ), val( adapters ), val( umis ), path( "*.with-adapters.fastq.gz" ), emit: main
+   tuple val( sample_id ), path( "*.with-adapters.fastq.gz" ), emit: main
    path( "*.log" ), emit: logs
 
    script:
+   def adapter_5prime_R = (adapters5[0].length() > 0 ? "-G '${adapters5[0]}'" : "")
    """
    for i in \$(seq 1 2)
    do
@@ -225,9 +333,9 @@ process TRIM_CUTADAPT {
    cutadapt \
 		-a "A{10}" \
       -A "T{10}" \
-		-q ${params.trim_qual} \
-		--nextseq-trim ${params.trim_qual} \
-		--minimum-length ${params.min_length} \
+		-q ${trim_qual} \
+		--nextseq-trim ${trim_qual} \
+		--minimum-length ${min_length} \
 		--report full \
       --action trim \
 		-o ${sample_id}_3prime_R1.fastq.gz \
@@ -235,9 +343,9 @@ process TRIM_CUTADAPT {
 		${sample_id}_polyA_R?.fastq.gz > ${sample_id}.polyA.cutadapt.log
 
    cutadapt \
-		-a "${adapters[0]}" \
-      -A "${adapters[1]}" \
-      --minimum-length ${params.min_length} \
+		-a "${adapters3[0]}" \
+      -A "${adapters3[1]}" \
+      --minimum-length ${min_length} \
 		--report full \
       --action trim \
 		-o ${sample_id}_5prime_R1.fastq.gz \
@@ -245,8 +353,7 @@ process TRIM_CUTADAPT {
 		${sample_id}_3prime_R?.fastq.gz > ${sample_id}.3prime.cutadapt.log
 
    cutadapt \
-		-g "${adapters[2]}" \
-      -G "${adapters[3]}" \
+		-g "${adapters5[1]}" ${adapter_5prime_R} \
 		--report full \
       --action retain \
 		-o ${sample_id}_R1.with-adapters.fastq.gz \
@@ -295,6 +402,80 @@ process UMITOOLS_WHITELIST {
    """
 }
 
+// Build whitelist from provided barcode files
+process BUILD_WHITELIST {
+   tag "${whitelist_id}"
+
+   publishDir( processed_o, 
+               mode: 'copy', 
+               pattern: "*.txt" )
+
+   input:
+   tuple val( whitelist_id ), path( bcs )
+
+   output:
+   tuple val( whitelist_id ), path( "*.whitelist.txt" )
+
+   script:
+   """
+   for f in ${bcs}
+   do
+      tail -n+2 \$f \
+      | tr -d \$'\\r' \
+      | sort \
+      | awk -F, -v OFS=, '{ print "__JOIN__", \$2 }' \
+      | sort -t, -k1 \
+      > \$f.temp
+   done
+
+   join -t, ${bcs[0]}.temp ${bcs[1]}.temp \
+   | join -t, - ${bcs[2]}.temp \
+   | awk -F, '{ print \$2\$3\$4 }' \
+   > ${whitelist_id}.whitelist.txt
+   """
+}
+
+// Build whitelist from provided barcode files
+process ADD_WHITELIST_ERRORS {
+   tag "${whitelist_id}"
+
+   publishDir( processed_o, 
+               mode: 'copy', 
+               pattern: "*.txt" )
+
+   input:
+   tuple val( whitelist_id ), path( whitelist )
+
+   output:
+   tuple val( whitelist_id ), path( "*.whitelist-err.txt" )
+
+   script:
+   """
+   #!/usr/bin/env python
+
+   from itertools import product
+
+   ALPHABET = "ATCG"
+   INPUT_FILE = "${whitelist}"
+   OUTPUT_FILE = "${whitelist_id}.whitelist-err.txt"
+
+   with open(OUTPUT_FILE, 'w') as outfile, open(INPUT_FILE, 'r') as infile:
+      for line in infile:
+         line = line.strip()
+         alternatives = (
+            f"{line[:i]}{letter}{line[(i+1):]}" 
+            for (i, char), letter in product(
+               enumerate(line), 
+               ALPHABET,
+            ) if char != letter
+         )
+         alternatives = ','.join(sorted(set(alternatives)))
+         print(f"{line}\\t{alternatives}", file=outfile)
+
+   """
+}
+
+
 /*
  * Extract cell barcodes and UMIs
  */
@@ -302,15 +483,18 @@ process UMITOOLS_EXTRACT {
 
    tag "${sample_id}"
 
+   errorStrategy 'retry'
+   maxRetries 2
+
    publishDir( processed_o, 
                mode: 'copy', 
                pattern: "*.extract.log" )
 
    input:
-   tuple val( genome_id ), val( sample_id ),  val( adapters ), val( umis ), path( reads )
+   tuple val( sample_id ), path( reads ), val( umis ), path( whitelist )
 
    output:
-   tuple val( genome_id ), val( sample_id ), path( "*.gz" ), emit: main
+   tuple val( sample_id ), path( "*.gz" ), emit: main
    path( "*.log" ), emit: logs
 
    script:
@@ -320,8 +504,8 @@ process UMITOOLS_EXTRACT {
 		--bc-pattern2 "${umis[1]}" \
       --extract-method regex \
       --error-correct-cell \
-      --quality-filter-mask ${params.trim_qual} \
       --quality-encoding phred33 \
+      --whitelist ${whitelist} \
       --log ${sample_id}.extract.log \
 		--stdin ${reads[0]} \
 		--read2-in ${reads[1]} \
@@ -338,10 +522,10 @@ process BOWTIE2_INDEX {
    tag "${genome_id}"
    
    input:
-   tuple val( genome_id ), path( fasta ), path( gff )
+   tuple val( genome_id ), path( fasta )
 
    output:
-   tuple val( genome_id ), path( "*.bt2" ), path( gff )
+   tuple val( genome_id ), path( "*.bt2" )
 
    script:
    """
@@ -354,22 +538,25 @@ process BOWTIE2_INDEX {
  */
 process BOWTIE2_ALIGN {
 
-   tag "${sample_id}-${genome_id}" 
+   tag "${sample_id}-${genome_acc}" 
+
+   errorStrategy 'retry'
+   maxRetries 2
 
    publishDir( path: processed_o, 
                mode: 'copy' )
 
    input:
-   tuple val( genome_id ), val( sample_id ), path( reads ), path( idx ), path( gff )
+   tuple val( sample_id ), path( reads ), path( idx ), val( genome_acc )
 
    output:
-   tuple val( genome_id ), path( gff ), val( sample_id ), path( "*.bam" ), path( "*.bai" ), emit: main
+   tuple val( sample_id ), path( "*.bam" ), emit: main
    path "*.log", emit: logs
 
    script:
    """
    bowtie2 \
-      -x ${genome_id} \
+      -x ${genome_acc} \
       --rdg 10,10 \
       --very-sensitive-local \
       -1 ${reads[0]} -2 ${reads[1]} \
@@ -377,7 +564,6 @@ process BOWTIE2_ALIGN {
       2> ${sample_id}.bowtie2.log
    samtools sort ${sample_id}.mapped.sam \
       -O bam -l 9 -o ${sample_id}.mapped.bam
-   samtools index ${sample_id}.mapped.bam
    rm ${sample_id}.mapped.sam
    """
 }
@@ -386,28 +572,61 @@ process BOWTIE2_ALIGN {
  * Dedupicate reads based on mapping coordinates and UMIs
  */
 process UMITOOLS_DEDUP {
-   errorStrategy 'ignore'
 
    tag "${sample_id}" 
 
+   label 'big_mem'
+   // errorStrategy 'retry'
+   // maxRetries 2
+
    publishDir( processed_o, 
-               mode: 'copy')
+               mode: 'copy' )
    input:
-   tuple val( genome_id ), path( gff ), val( sample_id ), path( bamfile ), path( bam_idx )
+   tuple val( sample_id ), path( bamfile )
 
    output:
-   tuple val( genome_id ), path( gff ), val( sample_id ), path( "*.bam" ), emit: main
+   tuple val( sample_id ), path( "*.bam" ), emit: main
    path( "*.log" ), emit: logs
    path( "*.tsv"), emit: stats
 
    script:
    """
+   samtools index ${bamfile}
    umi_tools dedup \
 		--per-cell \
-      --output-stats ${sample_id}.dedup \
+      --paired \
+      --method unique \
+      --chimeric-pairs discard \
+      --unmapped-reads discard \
 		--stdin ${bamfile} \
 		--log ${sample_id}.dedup.log \
       --stdout ${sample_id}.dedup.bam
+   #umicollapse bam -i ${bamfile} -o ${sample_id}.dedup.bam --paired --two-pass
+   """
+}
+
+
+process UMICOLLAPSE {
+
+   tag "${sample_id}" 
+
+   label 'big_mem'
+   // errorStrategy 'retry'
+   // maxRetries 2
+
+   publishDir( processed_o, 
+               mode: 'copy' )
+   input:
+   tuple val( sample_id ), path( bamfile ), path( umicollapse_repo )
+
+   output:
+   tuple val( sample_id ), path( "*.bam" ), emit: main
+   path( "*.log" ), emit: logs
+
+   script:
+   """
+   samtools index ${bamfile}
+   java -jar ${umicollapse_repo}/umicollapse.jar bam -i ${bamfile} -o ${sample_id}.dedup.bam --paired --two-pass 2>&1 > ${sample_id}.umicollapse.log
    """
 }
 
@@ -421,6 +640,9 @@ process FEATURECOUNTS {
 
    tag "${sample_id}"
 
+   errorStrategy 'retry'
+   maxRetries 2
+
    publishDir( counts_o, 
                mode: 'copy', 
                pattern: "*.tsv" )
@@ -429,22 +651,26 @@ process FEATURECOUNTS {
                pattern: "*.summary" )
 
    input:
-   tuple val( genome_id ), path( gff ), val( sample_id ), path( bamfile )
+   tuple val( sample_id ), path( bamfile ), path( gff )
 
    output:
-   tuple val( sample_id ), path( "*.bam" ), path( "*.bai" ), emit: main
+   tuple val( sample_id ), path( "*.bam" ), emit: main
    tuple path( "*.summary" ), path( "*.tsv" ), emit: logs
 
    script:
    """
+   samtools index ${bamfile}
    featureCounts \
-      -p -B -C -s ${params.strand} \
+      -p -C -s ${params.strand} \
       -d ${params.min_length} -D 10000  \
       -t ${params.ann_type} -g ${params.label} \
       -a ${gff} \
       -R BAM \
+      -T ${task.cpus} \
+      --countReadPairs \
+      --verbose \
+      --extraAttributes gene_biotype,locus_tag \
       -o ${sample_id}.featureCounts.tsv ${bamfile}
-   samtools index *featureCounts.bam
    """
 }
 
@@ -455,11 +681,14 @@ process UMITOOLS_COUNT {
 
    tag "${sample_id}"
 
+   errorStrategy 'retry'
+   maxRetries 2
+
    publishDir( counts_o, 
                mode: 'copy' )
 
    input:
-   tuple val( sample_id ), path( bamfile ), path( bam_idx )
+   tuple val( sample_id ), path( bamfile )
 
    output:
    tuple val( sample_id ), path( "*.tsv" ), emit: main
@@ -467,11 +696,13 @@ process UMITOOLS_COUNT {
 
    script:
    """
+   samtools index ${bamfile}
    umi_tools count \
-		--per-gene --per-cell \
+		--per-gene \
+      --per-cell \
 		--gene-tag XT \
       --log ${sample_id}.count.log \
-		--stdin  ${bamfile} \
+		--stdin ${bamfile} \
       --stdout ${sample_id}.umitools_count.tsv
    """
 }
@@ -480,6 +711,9 @@ process UMITOOLS_COUNT {
  * Make log report
  */
 process MULTIQC {
+
+   errorStrategy 'retry'
+   maxRetries 2
 
    publishDir( multiqc_o, 
                mode: 'copy' )

--- a/main.nf
+++ b/main.nf
@@ -28,19 +28,23 @@ if ( params.help ) {
          cell count table.
 
          Usage:
-            nextflow run sbcirlab/nf-sbrnaseq --sample_sheet <csv> --fastq-dir <dir>
+            nextflow run sbcirlab/nf-sbrnaseq --sample_sheet <csv> [--fastq-dir <dir>|--from-sra]
             nextflow run sbcirlab/nf-sbrnaseq -c <config-file>
 
          Required parameters:
-            sample_sheet         Path to a CSV containing sample IDs matched with FASTQ filenames, genome information, and adapter sequences.
-            fastq_dir            Path to directory containing the FASTQ file.
+            sample_sheet               Path to a CSV containing sample IDs matched with FASTQ filenames, genome information, and adapter sequences.
 
-         Optional parameters (with defaults):   
-            trim_qual = 5        For `cutadapt`, the minimum Phred score for trimming 3' calls
-            min_length = "9:38"  For `cutadapt`, the minimum trimmed length of a read. Shorter reads will be discarded
-            strand = 1           For `featureCounts`, the strandedness of RNA-seq. `1` for forward, `2` for reverse.
-            ann_type = 'gene'    For `featureCounts`, features from GFF column 3 to use for counting
-            label = 'Name'       For `featureCounts`, one or more (comma-separated) fields from column 9 of GFF for labeling counts
+         If using local FASTQ data (the default behavior):
+            fastq_dir                  Path to directory containing the FASTQ file.
+          
+         Optional parameters (with defaults):  
+            from_sra = false           Whether to fetch FASTQ data from the SRA.
+            allow_cell_errors = true   Whether to allow 1 error when matching cell barcodes in the whitelist.
+            trim_qual = 5              For `cutadapt`, the minimum Phred score for trimming 3' calls
+            min_length = "9:38"        For `cutadapt`, the minimum trimmed length of a read. Shorter reads will be discarded
+            strand = 1                 For `featureCounts`, the strandedness of RNA-seq. `1` for forward, `2` for reverse.
+            ann_type = 'gene'          For `featureCounts`, features from GFF column 3 to use for counting
+            label = 'Name'             For `featureCounts`, one or more (comma-separated) fields from column 9 of GFF for labeling counts
 
          The parameters can be provided either in the `nextflow.config` file or on the `nextflow run` command.
    

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,24 +12,20 @@ manifest {
 
 params {
     
-    help = null
+    help = false
     
     // *** Pipeline Input parameters ***
 
     sample_sheet = null
     fastq_dir = null
-
-    genome_fasta_dir = null
-    genome_gff_dir = null
+    inputs = "inputs"
+    outputs = "outputs"
 
     // *** Pipeline processing parameters ***
 
     // - Adapter trimming
     trim_qual = 5
     min_length = "9:38" 
-
-    // - UMI-tools
-    umitools_error = 2
 
     // - Feature counting
     // * Strandedness: 1 for forward, 2 for reverse
@@ -42,20 +38,84 @@ params {
     // This is one or more (comma-separated) fields
     // from column 9 of the GFF
     label = 'Name'
+
+    ncbi_api_key = 'f5b1dceea773296c6634439b7df13c09ad08'
+    umicollapse_repo = "https://github.com/siddharthab/UMICollapse.git"
 }
+
+conda {
+  enabled = true
+  createTimeout = '1 h'
+}
+process.conda = "${projectDir}/environment.yml"
 
 profiles {
 
   standard {
 
-    conda.enabled = true
-    conda.useMamba = true
-    conda.createTimeout = '1 h'
-    process.conda = "${projectDir}/environment.yml"
-    process.executor = 'slurm'
-    notification.enabled = true
-    notification.to = "$USER@crick.ac.uk"
+    process {
+      executor = 'slurm'
+    }
 
+    notification {
+      enabled = true
+      to = "$USER@crick.ac.uk"
+    }
+
+    dag {
+      enabled = true
+      overwrite = true
+    }
+
+    withLabel: big_cpu {
+      time = '3h'
+      cpus = 16
+      memory = 32.GB
+    }
+
+    withLabel: big_time {
+      time = '4d'
+      cpus = 1
+      memory = 64.GB
+    }
+
+    withLabel: some_mem {
+      memory = 16.GB
+    }
+
+    withLabel: med_mem {
+      memory = 64.GB
+    }
+
+    withLabel: big_mem {
+      memory = 128.GB
+    }
+
+    withLabel: gpu_single {
+      queue = 'gpu'
+      time = '7d'
+      module = 'cuDNN/8.9.2.26-CUDA-12.1.1'
+      cpus = 4
+      clusterOptions = '--gres=gpu:1'
+      memory = 128.GB
+    }
+
+    withLabel: gpu {
+      queue = 'gpu'
+      time = '4h'
+      module = 'cuDNN/8.9.2.26-CUDA-12.1.1'
+      cpus = 2
+      clusterOptions = '--gres=gpu:2'
+      memory = 128.GB
+    }
+
+  }
+
+  local {
+
+    process {
+      executor = 'local'
+    }
   }
 
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,9 +3,9 @@ manifest {
     author          = "Eachan O. Johnson"
     homePage        = "https://github.com/scbirlab/nf-sbrnaseq"
     description     = "Process demultiplexed Illumina paired-end FASTQ files from multiple bacterial samples into a gene x cell count table"
-    defaultBranch   = "main"
+    defaultBranch   = "0.0.4"
     nextflowVersion = '!>=22.10.1'
-    version         = "0.0.3"
+    version         = "0.0.4"
     doi             = ''
 
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,12 +20,15 @@ params {
     fastq_dir = null
     inputs = "inputs"
     outputs = "outputs"
+    from_sra = false
 
     // *** Pipeline processing parameters ***
 
     // - Adapter trimming
     trim_qual = 5
     min_length = "9:38" 
+
+    allow_cell_errors = true
 
     // - Feature counting
     // * Strandedness: 1 for forward, 2 for reverse
@@ -53,10 +56,6 @@ profiles {
 
   standard {
 
-    process {
-      executor = 'slurm'
-    }
-
     notification {
       enabled = true
       to = "$USER@crick.ac.uk"
@@ -67,46 +66,53 @@ profiles {
       overwrite = true
     }
 
-    withLabel: big_cpu {
-      time = '3h'
-      cpus = 16
-      memory = 32.GB
-    }
+    process {
+      
+      executor = 'slurm'
 
-    withLabel: big_time {
-      time = '4d'
-      cpus = 1
-      memory = 64.GB
-    }
+      withLabel: big_cpu {
+        time = '3h'
+        cpus = 16
+        memory = 32.GB
+      }
 
-    withLabel: some_mem {
-      memory = 16.GB
-    }
+      withLabel: big_time {
+        time = '4d'
+        cpus = 16
+        memory = 64.GB
+      }
 
-    withLabel: med_mem {
-      memory = 64.GB
-    }
+      withLabel: some_mem {
+        memory = 16.GB
+      }
 
-    withLabel: big_mem {
-      memory = 128.GB
-    }
+      withLabel: med_mem {
+        memory = 64.GB
+      }
 
-    withLabel: gpu_single {
-      queue = 'gpu'
-      time = '7d'
-      module = 'cuDNN/8.9.2.26-CUDA-12.1.1'
-      cpus = 4
-      clusterOptions = '--gres=gpu:1'
-      memory = 128.GB
-    }
+      withLabel: big_mem {
+        cpus = 16
+        memory = 128.GB
+      }
 
-    withLabel: gpu {
-      queue = 'gpu'
-      time = '4h'
-      module = 'cuDNN/8.9.2.26-CUDA-12.1.1'
-      cpus = 2
-      clusterOptions = '--gres=gpu:2'
-      memory = 128.GB
+      withLabel: gpu_single {
+        queue = 'gpu'
+        time = '7d'
+        module = 'cuDNN/8.9.2.26-CUDA-12.1.1'
+        cpus = 4
+        clusterOptions = '--gres=gpu:1'
+        memory = 128.GB
+      }
+
+      withLabel: gpu {
+        queue = 'gpu'
+        time = '4h'
+        module = 'cuDNN/8.9.2.26-CUDA-12.1.1'
+        cpus = 2
+        clusterOptions = '--gres=gpu:2'
+        memory = 128.GB
+      }
+
     }
 
   }


### PR DESCRIPTION
Main changes:
- Published FASTQ files can now be pulled from SRA for analysis
- If you provide the 3 sets of barcodes, it will build the whitelist for you
- You don't need to provide the genome files, only the NCBI assembly accession number (starting with GCA_ or GCF_)
- It will do some basic QC, filtering, and clustering in scanpy, and save the .h5ad file for downstream analysis
- Uses a [a fork of UMICollapse](https://github.com/siddharthab/UMICollapse) for UMI deduplication. Avoids the memory blowup of `umi_tools dedup`.