### PR TITLE
Use locus_tag as gene identifier and add chromosome to AnnData object

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -41,7 +41,7 @@ params {
     // What to use to label the features
     // This is one or more (comma-separated) fields
     // from column 9 of the GFF
-    label = 'Name'
+    label = 'locus_tag'
 
     ncbi_api_key = 'f5b1dceea773296c6634439b7df13c09ad08'
     umicollapse_repo = "https://github.com/siddharthab/UMICollapse.git"


### PR DESCRIPTION
When mapping to concatenated references, common gene symbols caused count collisions. Now the pipeline uses the locus_tag for gene ID, and the AnnData step includes the chromosome ID (as "chr").