### PR TITLE
Improvements to SRA downloads, deduplication, and counting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     g++ \
     perl liburi-perl \
+    zlib1g-dev \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 USER 1000

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Each time you run the pipeline after the first time, Nextflow will use a locally
 the pipeline, use the `-r <version>` flag. For example,
 
 ```bash 
-nextflow run scbirlab/nf-sbrnaseq -r v0.0.11
+nextflow run scbirlab/nf-sbrnaseq -r v0.0.12
 ```
 
 A list of versions can be found by running `nextflow info scbirlab/nf-sbrnaseq`.

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
     - pip:
         - 'carabiner-tools[mpl,pd]>=0.0.4'
         - 'cutadapt>=5.0'
-        - 'deeptools==3.5.3'
+        - 'deeptools==3.5.6'
         - 'multiqc>=1.27'
         - 'numpy>=2.1.3'
         - 'RSeQC'

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
     - bioconda
 
 dependencies:
-    - python==3.12
+    - python=3.12
     - pip
     - bioconda::bedops
     - bioconda::bowtie2

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
     - bioconda::minimap2
     - bioconda::perl-uri
     - bioconda::samtools
+    - bioconda::seqtk
     - bioconda::sra-tools
     - bioconda::star
     - bioconda::stringtie
@@ -23,6 +24,7 @@ dependencies:
     - conda-forge::libjpeg-turbo
     - conda-forge::openjdk
     - conda-forge::openssl
+    - conda-forge::pigz
     - conda-forge::r-base
     - conda-forge::r-essentials
     - conda-forge::unzip

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
     - bioconda
 
 dependencies:
-    - python=3.12
+    - python=3.11
     - pip
     - bioconda::bedops
     - bioconda::bedtools

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
     - python=3.12
     - pip
     - bioconda::bedops
+    - bioconda::bedtools
     - bioconda::bowtie2
     - bioconda::fastqc
     - bioconda::minimap2

--- a/main.nf
+++ b/main.nf
@@ -184,7 +184,7 @@ workflow {
          params.sample_sheet, 
          checkIfExists: true 
       )
-      .splitCsv( header: true )
+      .splitCsv( header: true, quote: '"' )
       .set { csv_ch }
 
    if ( params.nanopore ) {

--- a/modules/bowtie.nf
+++ b/modules/bowtie.nf
@@ -23,7 +23,7 @@ process bowtie2_index {
 process bowtie2_align {
 
    tag "${id}-${genome_acc}" 
-   label "big_mem"
+   label "big_cpu"
 
    errorStrategy 'retry'
    maxRetries 1

--- a/modules/count_utils.nf
+++ b/modules/count_utils.nf
@@ -17,40 +17,52 @@ process join_featurecounts_UMItools {
 
    script:
    """
-   get_col_number () (
-      local col="\$1"
-      local sep=\${2:-,}
-      head -n1 | tr "\$sep" \$'\\n' | grep -n "\$col" | cut -d: -f1
-   )
-   sort_table () (
-      local col=\${1:-"1"}
-      cat > "temp-table"
-      head -n1 "temp-table" \
-      | cat - <(tail -n+2 "temp-table" \
-      | LC_ALL=C sort -k"\$col" -d -t, --parallel=${task.cpus} --buffer-size="${task.memory.getBytes()}b") && rm "temp-table"
-   )
-   set -x
-   grep -v '^#' "${featurecounts_table}" | tr \$'\\t' , > "featurecounts-table0.csv"
-   LOCUS_TAG_COL=\$(get_col_number "Geneid" < "featurecounts-table0.csv")
-   # rename header, add locus tag column, and sort
-   sed 's/,${id}.*\\.umicollapse\\.bam\$/,bulk_read_count/' \
-      "featurecounts-table0.csv" \
-   | awk -F, -v OFS=, \
-      -v locus_col="\$LOCUS_TAG_COL" -v sample_id="${id}" \
-      'NR == 1 { print "gene_id", "sample_id", \$0 } NR > 1 { print \$locus_col, sample_id, \$0 } ' \
-   | sort_table \
-   > "featurecounts-table.csv"
+   #!/usr/bin/env python
 
-   cat ${umitools_table} | tr \$'\\t' , > "umitools-table0.csv"
-   sed 's/,count\$/,umi_count/;s/^gene,/gene_id,/;s/,cell,/,cell_barcode,/' \
-      "umitools-table0.csv" \
-   | sort_table \
-   > "umitools-table.csv"
+   import pandas as pd
 
-   LC_COLLATE=C join --header -j1 -t, --nocheck-order \
-      "featurecounts-table.csv" "umitools-table.csv" \
-   | tr , \$'\t' \
-   > "all-counts.tsv" 
+   featurecounts_df = (
+      pd.read_csv("${featurecounts_table}", sep="\\t", comment='#')
+      .rename(columns={"Chr": "chr"})
+      .assign(
+         sample_id="${id}",
+         gene_id=lambda x: x["Geneid"],
+      )
+   )
+
+   bam_cols = [col for col in featurecounts_df if col.endswith(".bam")]
+   featurecounts_df = featurecounts_df.rename(
+      columns={col: "pseudobulk_read_count" for col in bam_cols}
+   )
+
+   df_in = (
+      pd.read_csv("${umitools_table}", sep="\\t")
+      .assign(
+         sample_id="${id}",
+      )
+   )
+
+   df_out = (
+      featurecounts_df
+      .merge(
+         df_in,
+         how="outer",
+      )
+      .drop_duplicates()
+      .assign(
+         umi_count=lambda x: x["umi_count"].fillna(0).astype(int),
+         read_count=lambda x: x["read_count"].fillna(0).astype(int),
+      )
+   )
+
+   #if df_out.shape[0] != df_in.shape[0]:
+   #   raise ValueError(
+   #      f"Extra rows were added! {df_in.shape[0]=} -> {df_out.shape[0]=} "
+   #      f"(Featurecounts had {featurecounts_df.shape[0]} rows)."
+   #   )
+
+   df_out.to_csv("all-counts.tsv", sep="\\t", index=False)
+
    """
 }
 
@@ -62,7 +74,7 @@ process count_genomes_per_cell {
       "${params.outputs}/counts", 
       mode: 'copy',
       saveAs: { "${id}.${it}" },
-      pattern: "genome-per-cell*.tsv",
+      // pattern: "genome-per-cell*.tsv",
    )
 
    input:
@@ -70,47 +82,81 @@ process count_genomes_per_cell {
 
    output:
    tuple val( id ), path( "genome-per-cell{,-summary}.tsv" ), emit: chr_per_cell
+   tuple val( id ), path( "*.{png,tsv}" ), emit: plots
 
    script:
    """
-   get_col_number () (
-      local col="\$1"
-      local sep=\${2:-,}
-      head -n1 | tr "\$sep" \$'\\n' | grep -n "\$col" | cut -d: -f1
-   )
-   set -x
-   
-   # count the number of assemblies per cell
-   cell_bc_col=\$(get_col_number "cell_barcode" \$'\\t' < "${joined_table}")
-   chr_col=\$(get_col_number "Chr"  \$'\\t' < "${joined_table}")
-   genome_col=\$(get_col_number "genome_accession"  \$'\\t' < "${joined_table}")
-   awk -F'\\t' -v OFS='\\t' \
-      -v bc_col="cell_barcode" \
-      -v g_col="genome_accession" \
-      '
-      BEGIN { print bc_col, "n_genomes" } 
-      NR == 1 { for (i = 1; i <= NF; i++) col_idx[\$i]=i } 
-      NR > 1 {
-         bc = \$(col_idx[bc_col])
-         g = \$(col_idx[g_col])
-         key = bc SUBSEP g
-         if (!(key in seen)) {
-            seen[key]=1
-            counts[bc]++
-         }
-      }
-      END { for (bc in counts) print bc, counts[bc] }
-      ' \
-      "${joined_table}" \
-   > "genome-per-cell.tsv"
+   #!/usr/bin/env python
 
-   awk -F'\t' -v OFS='\t' \
-      '
-      BEGIN { print "n_genomes", "n_cell_barcodes_with_n_genomes" } 
-      NR > 1 { a[\$2]++ } 
-      END { for (key in a) print key, a[key] }
-      ' \
-      "genome-per-cell.tsv" \
-   > "genome-per-cell-summary.tsv"
+   import pandas as pd
+   from carabiner.mpl import figsaver, scattergrid
+
+   GENOME_KEY = "genome_accession"
+   CELL_BC_KEY = "cell_barcode"
+
+   df = pd.read_csv("${joined_table}", sep="\\t")#.query("gene_biotype != 'rRNA'")
+   n_genomes = df[GENOME_KEY].nunique()
+
+   df_sum = (
+      df
+      .groupby([CELL_BC_KEY, GENOME_KEY])
+      [["umi_count", "read_count"]]
+      .sum()
+      .reset_index()
+   )
+
+   cell_sums = (
+      df
+      .groupby(CELL_BC_KEY)
+      [["umi_count", "read_count"]]
+      .sum()
+   )
+
+   m = (
+      df_sum
+      .pivot(
+         index=CELL_BC_KEY,
+         columns=GENOME_KEY,
+         values=["umi_count", "read_count"],
+      )
+      .fillna(0)
+      .astype(int)
+   )
+   print(m.head())
+   m = m.loc[cell_sums.query("umi_count >= 2").index]
+   m.columns = [":".join(c) for c in m.columns.to_flat_index()]
+   m.to_csv("genome-per-cell.tsv", sep="\\t")
+
+   fig, axes = scattergrid(
+      m,
+      grid_columns=m.columns.tolist(),
+      #log=m.columns.tolist(),
+   )
+   figsaver(format="png")(
+      fig=fig,
+      name="genome-per-cell",
+      df=m.reset_index(),
+   )
+
+   df_hist = (
+      df_sum
+      .query("umi_count >= 2")
+      .groupby(CELL_BC_KEY)
+      [[GENOME_KEY]]
+      .nunique()
+      .reset_index()
+      .groupby(GENOME_KEY)
+      [[CELL_BC_KEY]]
+      .nunique()
+      .reset_index()
+      .rename(columns={
+         GENOME_KEY: "n_genomes_per_cell",
+         CELL_BC_KEY: "n_cells_with_n_genomes",
+      })
+   )
+
+   df_hist.to_csv("genome-per-cell-summary.tsv", sep="\\t", index=False)
+
    """
+
 }

--- a/modules/deeptools.nf
+++ b/modules/deeptools.nf
@@ -1,0 +1,77 @@
+process bam2wig {
+
+    tag "${id}"
+    label 'big_cpu'
+
+    errorStrategy 'ignore'
+
+    publishDir( 
+        "${params.outputs}/bigwig", 
+        mode: 'copy',
+    )
+
+    input:
+    tuple val( id ), path( bamfile )
+
+    output:
+    tuple val( id ), path( "${id}.bw" )
+
+    script:
+    """
+    samtools index "${bamfile}"
+    bamCoverage \
+        -b "${bamfile}" \
+        --outFileName "${id}.bw" \
+        --outFileFormat bigwig \
+        --binSize 1 \
+        --numberOfProcessors ${task.cpus}
+    
+    """
+}
+
+
+process plot_peaks {
+
+    tag "${id}"
+    label 'big_cpu'
+
+    errorStrategy 'ignore'
+
+    publishDir( 
+        "${params.outputs}/coverage", 
+        mode: 'copy',
+        saveAs: { "${id}.${it}" },
+    )
+
+    input:
+    tuple val( id ), path( bigwigs, stageAs: '??/*' ), path( ann_bed )
+
+    output:
+    tuple val( id ), path( "matrix.mat.gz" ), emit: matrix
+    tuple val( id ), path( "peak-heatmap.png" ), emit: plot
+
+    script:
+    """
+    export MPLCONFIGDIR=mpltemp
+    mkdir "\$MPLCONFIGDIR"
+
+    computeMatrix scale-regions \
+        --verbose \
+        -S ??/*.bw \
+        --regionsFileName "${ann_bed}" \
+        --regionBodyLength 100 \
+        --binSize 1 \
+        --numberOfProcessors ${task.cpus} \
+        -o matrix.mat.gz
+
+    plotHeatmap \
+        --verbose \
+        --matrixFile matrix.mat.gz \
+        --dpi 300 \
+        --colorMap cividis \
+        --legendLocation none \
+        --outFileName peak-heatmap.png
+    
+    """
+
+}

--- a/modules/featurecounts.nf
+++ b/modules/featurecounts.nf
@@ -6,66 +6,82 @@
 process featurecounts {
 
    tag "${id}"
-   label 'med_mem'
+   label 'big_cpu'
 
-   errorStrategy 'retry'
-   maxRetries 2
+   // errorStrategy 'retry'
+   // maxRetries 2
 
    publishDir( 
       "${params.outputs}/featurecounts", 
       mode: 'copy',
-      pattern: "*.log",
+      // pattern: "*.log",
    )
 
    input:
    tuple val( id ), path( bamfile ), path( gff )
    val paired
+   val strand
+   val annotation_type
+   val attribute_label
 
    output:
    tuple val( id ), path( "*.bam" ), emit: main
    tuple val( id ), path( "*.featureCounts.tsv" ), emit: table
+   tuple val( id ), path( "species-chr-map.tsv" ), emit: mapping
    path "*.{summary,log}", emit: logs
+
 
    script:
    """
    # make species -> chromosome mapping
-   cat \
-      <(printf 'genome_accession\\tChr\\n') \
-      <(awk -v OFS='\\t' \
-         '
-         /^#!genome-build-accession/ { split(\$2, _species, ":"); species = _species[2] } 
-         !/#/ { if (!(\$1 in chr)) chr[\$1] = species } 
-         END { for (key in chr) print chr[key], key}
-         ' \
-         "${gff}" \
-      | sort -k2) \
+   awk -F'\\t' -v OFS='\\t' '
+      BEGIN { print "taxon_url", "assembly", "genome_accession", "Chr" }
+      /^#!genome-build / { split(\$1, _assembly, " "); assembly = _assembly[2]; next } 
+      /^#!genome-build-accession / { split(\$1, _acc0, " "); split(_acc0[2], _acc, ":"); acc = _acc[2]; next }
+      /^##species / { split(\$1, _url, " "); taxon_url = _url[2]; next }
+      !/#/ { chr = \$1; if (!(chr in taxon)) {
+            taxon[chr] = taxon_url;
+            assem[chr] = assembly;
+            genom[chr] = acc;
+         }
+         next
+      } 
+      END { for (chr in taxon) print taxon[chr], assem[chr], genom[chr], chr }
+      ' \
+      "${gff}" \
    > species-chr-map.tsv
 
    samtools index "${bamfile}"
    featureCounts \
       -C \
-      -s ${params.strand} \
-      -t ${params.ann_type} \
-      -g ${params.label} \
+      -s ${strand ? strand : "0"} \
+      -t ${annotation_type} \
+      -g ${attribute_label} \
       -a "${gff}" \
       -R BAM \
       -T ${task.cpus} ${paired ? '--countReadPairs -p' : ''} \
       --verbose \
-      --extraAttributes Name,gene_biotype,locus_tag \
-      -o "${id}.featureCounts0.tsv" \
+      --extraAttributes ID,Name,gene_biotype,locus_tag \
+      -o "featureCounts0.tsv" \
       "${bamfile}"
-   mv "${id}.featureCounts0.tsv.summary" "${id}.featureCounts.tsv.summary"
-   cp "${id}.featureCounts.tsv.summary" "${id}.featureCounts.log"
+   mv "featureCounts0.tsv.summary" "featureCounts.tsv.summary"
+   cp "featureCounts.tsv.summary" "${id}.featureCounts.log"
 
-   cat \
-      <(head -n1 "${id}.featureCounts0.tsv") \
-      <(
-         cat \
-            <(head -n2 "${id}.featureCounts0.tsv" | tail -n1) \
-            <(tail -n+3 "${id}.featureCounts0.tsv" | sort -k2) \
-         | join species-chr-map.tsv - -j2 --header -t\$'\\t'
-      ) \
-   > "${id}.featureCounts.tsv"
+   python -c '
+   import pandas as pd
+
+   (
+      pd.read_csv(
+         "featureCounts0.tsv",
+         sep="\\t",
+         comment="#",
+      )
+      .merge(
+         pd.read_csv("species-chr-map.tsv", sep="\\t")
+      )
+      .to_csv("${id}.featureCounts.tsv", sep="\\t", index=False)
+   )
+   '
    
    """
 }

--- a/modules/minimap.nf
+++ b/modules/minimap.nf
@@ -30,8 +30,8 @@ process minimap_align {
    publishDir( 
       "${params.outputs}/mapped", 
       mode: 'copy',
-      saveAs: { "${id}.${it}" },
-      pattern: "*.{sam,log}"
+      // saveAs: { "${id}.${it}" },
+      pattern: "*.{bam,log}"
    )
 
    input:
@@ -39,15 +39,18 @@ process minimap_align {
    val nanopore
 
    output:
-   tuple val( id ), path( "minimap2.sam" ), emit: main
-   path "minimap2.log", emit: logs
+   tuple val( id ), path( "${id}.minimap2.bam" ), emit: main
+   path "${id}.minimap2.log", emit: logs
 
    script:
    """
-   minimap2 -a -c -2 --MD -x ${nanopore ? 'map-ont' : 'sr --frag=yes'} \
+   minimap2 -a -c -2 --MD \
+      -x ${nanopore ? 'map-ont' : 'sr --frag=yes'} \
       ${idx} ${reads} \
-      -o minimap2.sam \
-   2> minimap2.log
+      -o "${id}.minimap2.sam" \
+   2> ${id}.minimap2.log
+   samtools view -bS "${id}.minimap2.sam" -o "${id}.minimap2.bam"
+   rm "${id}.minimap2.sam"
 
    """
 }

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -2,7 +2,7 @@
 process fastQC {
 
    tag "${sample_id}"
-   label 'med_mem'
+   label 'big_cpu'
    
    input:
    tuple val( sample_id ), path ( reads )

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -1,27 +1,27 @@
 // Do quality control checks
 process fastQC {
 
-   tag "${sample_id}"
+   tag "${id}"
    label 'big_cpu'
    
    input:
-   tuple val( sample_id ), path ( reads )
+   tuple val( id ), path ( reads, stageAs: '??/*' )
 
    output:
-   tuple val( sample_id ), path ( "*.zip" ), emit: logs
+   tuple val( id ), path ( "*.zip" ), emit: logs
    path "*.zip", emit: multiqc_logs
 
    script:
    """
-   zcat ${reads} > ${sample_id}.fastq
-   fastqc --noextract --memory 10000 --threads ${task.cpus} ${sample_id}.fastq
-   rm ${sample_id}.fastq
+   zcat ??/*.fastq.gz > "${id}.fastq"
+   fastqc --noextract --memory 10000 --threads ${task.cpus} "${id}.fastq"
+   rm "${id}.fastq"
    """
    stub:
    """
-   zcat ${reads} | head -n1000 > ${sample_id}.fastq
-   fastqc --noextract --memory 10000 --threads ${task.cpus} ${sample_id}.fastq
-   rm ${sample_id}.fastq
+   zcat ??/*.fastq.gz | head -n1000 > "${id}.fastq"
+   fastqc --noextract --memory 10000 --threads ${task.cpus} "${id}.fastq"
+   rm "${id}.fastq"
    """
 
 }

--- a/modules/samtools.nf
+++ b/modules/samtools.nf
@@ -1,7 +1,7 @@
 process SAMtools_stats {
 
     tag "${id}"
-    label 'med_mem'
+    label 'big_cpu'
 
     publishDir( 
         "${params.outputs}/samtools", 
@@ -50,7 +50,7 @@ process plot_bamstats {
 process SAMtools_flagstat {
 
     tag "${id}"
-    label 'med_mem'
+    label 'big_cpu'
 
     publishDir( 
         "${params.outputs}/samtools", 
@@ -79,7 +79,6 @@ process SAMtools_flagstat {
 process SAMtools_coverage {
 
     tag "${id}"
-    label 'med_mem'
 
     publishDir( 
         "${params.outputs}/samtools", 
@@ -103,7 +102,7 @@ process SAMtools_coverage {
 process remove_multimappers {
 
     tag "${id}"
-    label 'med_mem'
+    label 'big_mem'
 
     // publishDir( 
     //     "${params.outputs}/samtools", 
@@ -115,17 +114,16 @@ process remove_multimappers {
     tuple val( id ), path( bamfile )
 
     output:
-    tuple val( id ), path( "sorted.{bam,bai}" )
+    tuple val( id ), path( "*.sorted.{bam,bai}" )
 
     script:
     """
     # filter out multimappers
-    samtools view -@ ${task.cpus} -F260 -bS -q 3 "${bamfile}" -o filtered.bam
-    samtools sort -@ ${task.cpus} -m ${Math.round(task.memory.getGiga() * 0.8)}G filtered.bam -o sorted.bam
-    samtools index sorted.bam
+    #samtools view -@ ${task.cpus} -F2308 -bS --min-MQ 1 "${bamfile}" -o filtered.bam
+    samtools view -@ ${task.cpus} -bS --min-MQ 1 "${bamfile}" -o filtered.bam
+    samtools sort -@ ${task.cpus} -m ${Math.round(task.memory.getGiga() * 0.8)}G filtered.bam -o "${id}.sorted.bam"
+    samtools index "${id}.sorted.bam" -o "${id}.sorted.bai"
     rm filtered.bam
     """
 
 }
-
-

--- a/modules/samtools.nf
+++ b/modules/samtools.nf
@@ -26,6 +26,8 @@ process plot_bamstats {
 
     tag "${id}"
 
+    errorStrategy 'ignore'
+
     publishDir( 
         "${params.outputs}/samtools", 
         mode: 'copy',
@@ -44,7 +46,6 @@ process plot_bamstats {
     """
 
 }
-
 
 
 process SAMtools_flagstat {
@@ -119,11 +120,12 @@ process remove_multimappers {
     script:
     """
     # filter out multimappers
-    #samtools view -@ ${task.cpus} -F2308 -bS --min-MQ 1 "${bamfile}" -o filtered.bam
-    samtools view -@ ${task.cpus} -bS --min-MQ 1 "${bamfile}" -o filtered.bam
-    samtools sort -@ ${task.cpus} -m ${Math.round(task.memory.getGiga() * 0.8)}G filtered.bam -o "${id}.sorted.bam"
+    #samtools view -@ ${task.cpus} -F2308 -bS --min-MQ=1 "${bamfile}" -o filtered.bam
+    samtools view -@ ${task.cpus} -bS "${bamfile}" -o filtered.bam
+    samtools sort -@ ${task.cpus} -m 2G filtered.bam -o "${id}.sorted.bam"
     samtools index "${id}.sorted.bam" -o "${id}.sorted.bai"
     rm filtered.bam
+    
     """
 
 }

--- a/modules/samtools.nf
+++ b/modules/samtools.nf
@@ -6,18 +6,18 @@ process SAMtools_stats {
     publishDir( 
         "${params.outputs}/samtools", 
         mode: 'copy',
-        saveAs: { "${id}.${it}" },
+        // saveAs: { "${id}.${it}" },
     )
 
     input:
     tuple val( id ), path( bamfile )
 
     output:
-    tuple val( id ), path( "stats.txt" )
+    tuple val( id ), path( "${id}.stats.txt" )
 
     script:
     """
-    samtools stats -@ ${task.cpus} "${bamfile[0]}" > stats.txt
+    samtools stats -@ ${task.cpus} "${bamfile[0]}" > "${id}.stats.txt"
     """
 
 }
@@ -31,18 +31,18 @@ process plot_bamstats {
     publishDir( 
         "${params.outputs}/samtools", 
         mode: 'copy',
-        saveAs: { "${id}.${it}" },
+        // saveAs: { "${id}.${it}" },
     )
 
     input:
     tuple val( id ), path( txt )
 
     output:
-    tuple val( id ), path( "stats-*.png" )
+    tuple val( id ), path( "${id}-*.png" )
 
     script:
     """
-    plot-bamstats -p stats "${txt}"
+    plot-bamstats -p "${id}" "${txt}"
     """
 
 }
@@ -56,14 +56,14 @@ process SAMtools_flagstat {
     publishDir( 
         "${params.outputs}/samtools", 
         mode: 'copy',
-        saveAs: { "${id}.${it}" },
+        // saveAs: { "${id}.${it}" },
     )
 
     input:
     tuple val( id ), path( bamfile )
 
     output:
-    tuple val( id ), path( "flagstat.tsv" )
+    tuple val( id ), path( "${id}.flagstat.tsv" )
 
     script:
     """
@@ -72,7 +72,7 @@ process SAMtools_flagstat {
     #| samtools sort -@ ${task.cpus} -m ${Math.round(task.memory.getGiga() * 0.8)}G -u - \
     #| samtools markdup -@ ${task.cpus} - markdup.bam
     #samtools flagstat -@ ${task.cpus} -O tsv markdup.bam > flagstat.tsv
-    samtools flagstat -@ ${task.cpus} -O tsv "${bamfile[0]}" > flagstat.tsv
+    samtools flagstat -@ ${task.cpus} -O tsv "${bamfile[0]}" > "${id}.flagstat.tsv"
     """
 
 }
@@ -82,20 +82,20 @@ process SAMtools_coverage {
     tag "${id}"
 
     publishDir( 
-        "${params.outputs}/samtools", 
+        "${params.outputs}/samtools-coverage", 
         mode: 'copy',
-        saveAs: { "${id}.${it}" },
+        // saveAs: { "${id}.${it}" },
     )
 
     input:
     tuple val( id ), path( bamfile )
 
     output:
-    tuple val( id ), path( "coverage.tsv" )
+    tuple val( id ), path( "${id}.tsv" )
 
     script:
     """
-    samtools coverage "${bamfile[0]}" -o coverage.tsv
+    samtools coverage "${bamfile[0]}" -o "${id}.tsv"
     """
 
 }

--- a/modules/scanpy.nf
+++ b/modules/scanpy.nf
@@ -2,6 +2,8 @@ process build_AnnData {
    tag "${id}"
    label "big_mem"
 
+   errorStrategy 'ignore'
+
    publishDir( 
       "${params.outputs}/scanpy", 
       mode: 'copy',
@@ -62,6 +64,8 @@ process cluster_cells {
 
    tag "${id}"
    label "med_mem"
+
+   errorStrategy 'ignore'
 
    publishDir( 
       "${params.outputs}/clustering", 

--- a/modules/scanpy.nf
+++ b/modules/scanpy.nf
@@ -14,7 +14,7 @@ process build_AnnData {
    output:
    tuple val( id ), path( "*.h5ad" ), emit: main
    tuple val( id ), path( "*.{png,csv}" ), emit: plots
-   path "*.log", emit: logs
+   path "build.log", emit: logs
 
    script:
    """
@@ -22,7 +22,7 @@ process build_AnnData {
    export NUMBA_CACHE_DIR="numba"
    mkdir "\$MPLCONFIGDIR" "\$NUMBA_CACHE_DIR"
 
-   python ${projectDir}/bin/anndata-utils.py build "${counts_table}" --id "${id}" -o "build" 2> build.log
+   python ${projectDir}/bin/anndata-utils.py build "${counts_table}" --id "${id}" -o "build"  2> >(tee build.log)
 
    """
 }
@@ -51,7 +51,8 @@ process filter_AnnData {
    export NUMBA_CACHE_DIR="numba"
    mkdir "\$MPLCONFIGDIR" "\$NUMBA_CACHE_DIR"
 
-   python ${projectDir}/bin/anndata-utils.py filter "${anndata}" -o filter 2> filter.log
+   python ${projectDir}/bin/anndata-utils.py filter "${anndata}" -o filter 2> >(tee filter.log)
+
 
    """
 }
@@ -81,7 +82,8 @@ process cluster_cells {
    export NUMBA_CACHE_DIR="numba"
    mkdir "\$MPLCONFIGDIR" "\$NUMBA_CACHE_DIR"
 
-   python ${projectDir}/bin/anndata-utils.py cluster "${anndata}" -o cluster 2> cluster.log
+   python ${projectDir}/bin/anndata-utils.py cluster "${anndata}" -o cluster 2> >(tee cluster.log)
+
    mv figures/*.png .
    
    """

--- a/modules/scanpy.nf
+++ b/modules/scanpy.nf
@@ -18,16 +18,12 @@ process build_AnnData {
 
    script:
    """
-   SCR="\$PWD/.scratch"
-   mkdir -p "\$SCR" "\$SCR/mpl" "\$SCR/xdg/fontconfig" "\$SCR/numba" "\$SCR/home" build
-
-   export HOME="\$SCR/home"
-   export MPLBACKEND=Agg
-   export MPLCONFIGDIR="\$SCR/mpl"
-   export XDG_CACHE_HOME="\$SCR/xdg"
-   export NUMBA_CACHE_DIR="\$SCR/numba"
+   export MPLCONFIGDIR="mpl"
+   export NUMBA_CACHE_DIR="numba"
+   mkdir "\$MPLCONFIGDIR" "\$NUMBA_CACHE_DIR"
 
    python ${projectDir}/bin/anndata-utils.py build "${counts_table}" --id "${id}" -o "build" 2> build.log
+
    """
 }
 
@@ -51,16 +47,12 @@ process filter_AnnData {
 
    script:
    """
-   SCR="\$PWD/.scratch"
-   mkdir -p "\$SCR" "\$SCR/mpl" "\$SCR/xdg/fontconfig" "\$SCR/numba" "\$SCR/home" build
-
-   export HOME="\$SCR/home"
-   export MPLBACKEND=Agg
-   export MPLCONFIGDIR="\$SCR/mpl"
-   export XDG_CACHE_HOME="\$SCR/xdg"
-   export NUMBA_CACHE_DIR="\$SCR/numba"
+   export MPLCONFIGDIR="mpl"
+   export NUMBA_CACHE_DIR="numba"
+   mkdir "\$MPLCONFIGDIR" "\$NUMBA_CACHE_DIR"
 
    python ${projectDir}/bin/anndata-utils.py filter "${anndata}" -o filter 2> filter.log
+
    """
 }
 
@@ -85,16 +77,12 @@ process cluster_cells {
 
    script:
    """
-   SCR="\$PWD/.scratch"
-   mkdir -p "\$SCR" "\$SCR/mpl" "\$SCR/xdg/fontconfig" "\$SCR/numba" "\$SCR/home" build
-
-   export HOME="\$SCR/home"
-   export MPLBACKEND=Agg
-   export MPLCONFIGDIR="\$SCR/mpl"
-   export XDG_CACHE_HOME="\$SCR/xdg"
-   export NUMBA_CACHE_DIR="\$SCR/numba"
+   export MPLCONFIGDIR="mpl"
+   export NUMBA_CACHE_DIR="numba"
+   mkdir "\$MPLCONFIGDIR" "\$NUMBA_CACHE_DIR"
 
    python ${projectDir}/bin/anndata-utils.py cluster "${anndata}" -o cluster 2> cluster.log
    mv figures/*.png .
+   
    """
 }

--- a/modules/star.nf
+++ b/modules/star.nf
@@ -26,6 +26,7 @@ process STAR_index {
       --sjdbGTFtagExonParentGene Parent \
       --sjdbGTFtagExonParentGeneName gene \
       --sjdbGTFtagExonParentGeneType gene_biotype
+
    """
 }
 
@@ -34,8 +35,8 @@ process STAR_index {
  */
 process STAR_align {
 
-   tag "${id}-${genome_acc}" 
-   label "big_mem"
+   tag "${id}:${genome_acc}" 
+   label "big_cpu"
    time "2d"
 
    // errorStrategy 'retry'
@@ -66,12 +67,14 @@ process STAR_align {
    STAR \
       --runMode alignReads \
       --runThreadN ${task.cpus} \
-      --genomeDir ${idx} \
+      --genomeDir "${idx}" \
       --readFilesIn ${reads} \
       --readFilesCommand zcat \
       --alignEndsType Local \
       --alignIntronMax 1 \
-      --outFilterMultimapNmax 1 \
+      --outFilterMultimapNmax 10 \
+      --outSAMmapqUnique 255 \
+      --outSAMprimaryFlag AllBestScore \
       --outSAMattributes All \
       --outSAMattrIHstart 0 \
       --twopassMode None \

--- a/modules/star.nf
+++ b/modules/star.nf
@@ -45,8 +45,14 @@ process STAR_align {
    publishDir( 
       "${params.outputs}/mapped", 
       mode: 'copy',
-      saveAs: { "${id}.${it}" },
+      saveAs: { "${id}.star.bam" },
       pattern: "*.bam"
+   )
+   publishDir( 
+      "${params.outputs}/mapped", 
+      mode: 'copy',
+      saveAs: { "${id}.${it}" },
+      pattern: "*.{bg,tab}"
    )
    publishDir( 
       "${params.outputs}/mapped", 
@@ -57,9 +63,11 @@ process STAR_align {
 
    input:
    tuple val( id ), path( reads ), path( idx ), val( genome_acc )
+   val strand
 
    output:
-   tuple val( id ), path( "Aligned.out.bam" ), emit: main
+   tuple val( id ), path( "Aligned*.out.bam" ), emit: main
+   tuple val( id ), path( "*.bg" ), emit: bg
    path "Log.final.out", emit: logs
 
    script:
@@ -72,14 +80,16 @@ process STAR_align {
       --readFilesCommand zcat \
       --alignEndsType Local \
       --alignIntronMax 1 \
-      --outFilterMultimapNmax 10 \
-      --outSAMmapqUnique 255 \
+      --outFilterMultimapNmax 20 \
       --outSAMprimaryFlag AllBestScore \
-      --outSAMattributes All \
+      --outSAMattributes NH HI NM MD AS nM \
       --outSAMattrIHstart 0 \
       --twopassMode None \
       --quantMode GeneCounts \
-      --outSAMtype BAM Unsorted
-
+      --outWigType bedGraph read1_5p \
+      --outSAMtype BAM SortedByCoordinate \
+      --outBAMsortingThreadN ${task.cpus} \
+      --limitBAMsortRAM ${Math.round(task.memory.getBytes() * 0.8)}
+   
    """
 }

--- a/modules/star.nf
+++ b/modules/star.nf
@@ -45,19 +45,19 @@ process STAR_align {
    publishDir( 
       "${params.outputs}/mapped", 
       mode: 'copy',
-      saveAs: { "${id}.star.bam" },
+      // saveAs: { "${id}.star.bam" },
       pattern: "*.bam"
    )
    publishDir( 
       "${params.outputs}/mapped", 
       mode: 'copy',
-      saveAs: { "${id}.${it}" },
+      // saveAs: { "${id}.${it}" },
       pattern: "*.{bg,tab}"
    )
    publishDir( 
       "${params.outputs}/mapped", 
       mode: 'copy',
-      saveAs: { "${id}.star.log" },
+      // saveAs: { "${id}.star.log" },
       pattern: "Log.final.out"
    )
 
@@ -66,9 +66,10 @@ process STAR_align {
    val strand
 
    output:
-   tuple val( id ), path( "Aligned*.out.bam" ), emit: main
-   tuple val( id ), path( "*.bg" ), emit: bg
-   path "Log.final.out", emit: logs
+   tuple val( id ), path( "${id}.star.bam" ), emit: main
+   tuple val( id ), path( "*.star.bg" ), emit: bg
+   tuple val( id ), path( "*.star.tab" ), emit: tab
+   path "${id}.star.log", emit: logs
 
    script:
    """
@@ -90,6 +91,15 @@ process STAR_align {
       --outSAMtype BAM SortedByCoordinate \
       --outBAMsortingThreadN ${task.cpus} \
       --limitBAMsortRAM ${Math.round(task.memory.getBytes() * 0.8)}
+
+   mv "Aligned.sortedByCoord.out.bam" "${id}.star.bam"
+   mv "Log.final.out" "${id}.star.log"
+   mv ReadsPerGene.out.tab "${id}.star.tab"
+
+   for f in *.bg
+   do
+      mv "\$f" "\$(basename \$f .bg)".star.bg
+   done
    
    """
 }

--- a/modules/trimming.nf
+++ b/modules/trimming.nf
@@ -15,7 +15,7 @@ process trim_using_cutadapt {
    )
 
    input:
-   tuple val( id ), path( reads, stageAs: "?/*" ), val( adapters5 ), val( adapters3 )
+   tuple val( id ), path( reads, stageAs: "???/*" ), val( adapters5 ), val( adapters3 )
    tuple val( trim_qual ), val( min_length )
 
    output:
@@ -29,7 +29,7 @@ process trim_using_cutadapt {
    """
    for i in \$(seq 1 2)
    do
-      cat */*_R"\$i"*.fastq.gz > ${id}_3p_R"\$i".fastq.gz
+      cat ???/*_R"\$i"*.fastq.gz > ${id}_3p_R"\$i".fastq.gz
    done
 
    cutadapt \

--- a/modules/trimming.nf
+++ b/modules/trimming.nf
@@ -4,7 +4,7 @@
 process trim_using_cutadapt {
 
    tag "${id}:q > ${trim_qual}:l > ${min_length}"
-   label "big_mem" 
+   label "big_cpu" 
    
    // errorStrategy 'retry'
    // maxRetries 1

--- a/modules/trimming.nf
+++ b/modules/trimming.nf
@@ -58,11 +58,12 @@ process trim_using_cutadapt {
          -j ${task.cpus} \
          -o ${id}_R1.with-adapters.fastq.gz \
          -p ${id}_R2.with-adapters.fastq.gz \
-         ${id}_5p_R?.fastq.gz > ${id}.5p.cutadapt.log
+         ${id}_5p_R?.fastq.gz \
+         > ${id}.5p.cutadapt.log
    else
       for i in \$(seq 1 2)
       do
-         mv ${id}_5p_R\$i.fastq.gz ${id}_R\$i.with-adapters.fastq.gz
+         cp ${id}_5p_R\$i.fastq.gz ${id}_R\$i.with-adapters.fastq.gz
       done
    fi
 

--- a/modules/umicollapse.nf
+++ b/modules/umicollapse.nf
@@ -31,16 +31,19 @@ process UMIcollapse {
    
    input:
    tuple val( id ), path( bamfile ), path( umicollapse_repo )
+   val paired
 
    output:
-   tuple val( id ), path( "*.bam" ), emit: main
-   path( "*.log" ), emit: logs
+   tuple val( id ), path( "*.umicollapse.bam" ), emit: main
+   path "*.log", emit: logs
 
    script:
    """
-   samtools view -h "${bamfile[1]}" \
+   set -euox pipefail
+
+   samtools view -h ${paired ? "" : "-f128"} "${bamfile[1]}" \
    | awk -F'\\t' -v OFS='\\t' '
-      /^@/ { print \$0; next }
+      /^@/ { print; next }
       !/^@/ {
          delete a
          split(\$1, a, "_"); 
@@ -49,16 +52,91 @@ process UMIcollapse {
          next
       }
    ' \
-   | samtools view -h -bS -o "cb-prepended.bam"
+   | samtools sort - -@${task.cpus} -m 2G -t CB \
+   | samtools view -bS - -o "cb-prepended.bam"
 
-   samtools index "cb-prepended.bam"
-   java -jar -Xmx${Math.round(task.memory.getGiga() * 0.8)}G -Xss1024m \
-      ${umicollapse_repo}/umicollapse.jar bam \
-      --paired \
-      --tag \
-      -i "cb-prepended.bam" \
+   mkdir -p shards
+   samtools view -H cb-prepended.bam > shards/_hdr.sam
+
+   samtools view -@${task.cpus} cb-prepended.bam \
+   | awk -v dir="shards" '
+      BEGIN { FS = OFS = "\\t" }
+      {
+         cb="";
+         for(i=12;i<=NF;i++) if(\$i ~ /^CB:Z:/){ split(\$i,a,":"); cb=a[3]; break }
+         if(cb == "") next
+         pref = substr(cb,1,4); 
+         if(pref == "") pref = "NNNN"
+         print >> (dir "/" pref ".sam")
+      }
+   '
+
+   for f in shards/*.sam; do
+      if [ "\$f" != "shards/_hdr.sam" ]
+      then
+         b=\${f%.sam}.bam
+         cat shards/_hdr.sam "\$f" \
+         | samtools view -@${task.cpus} -b -o "\$b" -
+         rm -f "\$f"
+
+         # sort by coordinate and stamp header as coordinate
+         samtools sort -@${task.cpus} -m 2G -o "\$b".coord.bam "\$b"
+         # ensure @HD SO:coordinate (reheader if needed)
+         samtools view -H "\$b".coord.bam \
+         | awk '
+            BEGIN { done = 0 } 
+            /^@HD/ && \$0 ~ /SO:/ { sub(/SO:[^ \\t]+/,"SO:coordinate"); done=1 } 
+            { print } 
+            END { if(!done) print "@HD\\tVN:1.6\\tSO:coordinate" }
+         ' \
+         > hdr.coord.sam
+         samtools reheader hdr.coord.sam "\$b".coord.bam > "\$b".coord.SOcoord.bam
+         samtools index "\$b".coord.SOcoord.bam
+
+         java -jar \
+            -Xmx${Math.round(task.memory.getGiga() * 0.8)}G \
+            -Xss1024m \
+               "${umicollapse_repo}/umicollapse.jar" \
+               bam ${paired ? "--paired" : ""} \
+               --tag \
+               -i "\$b".coord.SOcoord.bam \
+               -o "\$b".dedup.bam \
+         2>&1 >> "${id}.umicollapse.log"
+         rm "\$b".coord.SOcoord.bam hdr.coord.sam "\$b".coord.bam
+      fi
+   done
+
+   if [ ! -e "${id}.umicollapse.log" ]
+   then
+      echo "There were no reads in ${bamfile[1]}" > "${id}.umicollapse.log"
+   fi
+
+   if ls shards/*.dedup.bam > /dev/null 2>&1
+   then
+      samtools merge -@${task.cpus} \
+         -h cb-prepended.bam \
+         -o merged.dedup.bam \
+         shards/*.dedup.bam
+   else
+      samtools view -H cb-prepended.bam -o merged.dedup.bam
+   fi
+
+   samtools sort -@${task.cpus} -m 2G \
       -o "${id}.umicollapse.bam" \
-   2>&1 > "${id}.umicollapse.log"
+      merged.dedup.bam
+
+   samtools index "${id}.umicollapse.bam"
+   rm merged.dedup.bam
+   
+   start_count=\$(samtools view -c "cb-prepended.bam")
+   end_count=\$(samtools view -c "${id}.umicollapse.bam")
+   if [ "\$start_count" -gt "\$end_count"]
+   then
+      >&2 echo "Lost some reads during duplicate tagging!"
+      >&2 echo "- Initial count: \$start_count"
+      >&2 echo "- Count after tagging: \$end_count"
+      exit 1
+   fi
 
    mv "${id}.umicollapse.bam" "${id}.umicollapse-prep.bam"
    samtools view -h "${id}.umicollapse-prep.bam" \

--- a/modules/umitools.nf
+++ b/modules/umitools.nf
@@ -26,46 +26,267 @@ process UMItools_extract {
    script:
    def error_correct = ( params.allow_cell_errors ? "--error-correct-cell" : "" )
    def second_reads  = ( 
-      reads[1] 
-      ? "--bc-pattern '${umis[0]}' --bc-pattern2 '${umis[1]}' --read2-in '${reads[1]}' --read2-out \${f}_R2.fastq.gz"
-      : "--bc-pattern '${umis}'" 
+      reads[1]
+      ? "--bc-pattern2 '${umis[1]}' --read2-in '${reads[1]}' --read2-out '${id}'_R2.extracted0.fastq.gz"
+      : "" 
    )
    """
-   MAX_SIZE=500000000  # 500 million
-   split -l \$MAX_SIZE "${whitelist}" chunk_
-
-   for f in chunk_*
-   do
-      umi_tools extract \
-         --extract-method regex ${error_correct} \
-         --quality-encoding phred33 \
-         --whitelist "\$f" \
-         --log "${id}.\$f.extract.log" \
-         --stdin "${reads[0]}" \
-         --stdout "\$f"_R1.fastq.gz ${second_reads}
-   done
-
-   for i in 1 ${reads[1] ? '2' : ''}
-   do
-      cat chunk_*_R\$i.fastq.gz > ${id}_R\$i.extracted0.fastq.gz
-   done
+   zcat "${whitelist}" > wl.txt
+   umi_tools extract \
+      --extract-method regex ${error_correct} \
+      --quality-encoding phred33 \
+      --whitelist "wl.txt" \
+      --bc-pattern '${umis[0]}' \
+      --log "${id}.${whitelist.baseName}.extract.log" \
+      --stdin "${reads[0]}" \
+      --stdout "${id}"_R1.extracted0.fastq.gz ${second_reads}
 
    # make sure no 0-length reads
-   for f in ${id}_R?.extracted0.fastq.gz
+   for f in "${id}"_R?.extracted0.fastq.gz
    do
       zcat \$f \
-         | awk \
-            '
-            NR%4 == 1 { name = \$0 } 
-            NR%4 == 2 { if (length(\$0) > 0) { seq = \$0 } else { seq = "N" } } 
-            NR%4 == 0 { if (length(\$0) > 0) { qual = \$0 } else { qual = "?" } } 
-            ( NR > 1 && NR%4 == 1 ) { print name ORS seq ORS "+" ORS qual } 
-            END { print name ORS seq ORS "+" ORS qual }
-            ' \
-         | gzip \
+      | awk '
+         NR % 4 == 1 { name = \$0 } 
+         NR % 4 == 2 { if (length(\$0) > 0) { seq = \$0 } else { seq = "N" } } 
+         NR % 4 == 0 { if (length(\$0) > 0) { qual = \$0 } else { qual = "?" } } 
+         ( NR > 1 && NR % 4 == 1 ) { print name ORS seq ORS "+" ORS qual } 
+         END { print name ORS seq ORS "+" ORS qual }
+         ' \
+      | pigz -v --stdout -p ${task.cpus} \
       > \$(basename \$f .fastq.gz).extracted.fastq.gz
    done
-   rm ${id}_R?.extracted0.fastq.gz chunk_*_R?.fastq.gz
+
+   rm "${id}"_R?.extracted0.fastq.gz
+
+   """
+}
+
+process concat_extractions {
+
+   tag "${id}"
+
+   // errorStrategy 'retry'
+   // maxRetries 2
+
+   // publishDir( 
+   //    "${params.outputs}/extracted", 
+   //    mode: 'copy',
+   //    pattern: "*.extract.log", 
+   // )
+
+   input:
+   tuple val( id ), path( reads, stageAs: '??/*' )
+
+   output:
+   tuple val( id ), path( "*.extracted-concat.fastq.gz", arity: 1..2 )
+
+   script:
+   """
+   cat ??/*_R1.*extracted.fastq.gz > "${id}"_R1.extracted-concat.fastq.gz
+   if ls ??/*_R2.*extracted.fastq.gz 1> /dev/null 2>&1
+   then
+      cat ??/*_R2.*extracted.fastq.gz > "${id}"_R2.extracted-concat.fastq.gz
+   fi
+
+   """
+
+}
+
+process bam2table {
+
+   tag "${id}"
+
+   publishDir( 
+      "${params.outputs}/counts", 
+      mode: 'copy',
+      saveAs: { "${id}.${it}" },
+   )
+
+   input:
+   tuple val( id ), path( bamfile )
+
+   output:
+   tuple val( id ), path( "tab.tsv" )
+
+   script:
+   """
+   samtools view -h -F3972 --tag 'XS:Assigned' "${bamfile}" -bS -o filtered.bam
+
+   samtools view filtered.bam \
+   | awk -F'\\t' -v OFS='\\t' '
+      BEGIN { print "read_id", "gene_id", "chr", "cell_barcode", "umi", "umi_cluster_size", "umi_read_count" }
+      {
+         assign=""; gene=""; cb=""; umi=""; umi_read_count=""; umi_cluster_size="";
+         chr=\$3;
+         delete b; delete a;
+         split(\$1, b, "_");
+         cb = b[length(b) - 1]
+         for (i=12; i<=NF; i++) {
+            if (\$i ~ /^XS:Z:/) { split(\$i, a, ":"); assign = a[3] }
+            else if (\$i ~ /^XT:Z:/) { split(\$i, a, ":"); gene = a[3] }
+            else if (\$i ~ /^RX:Z:/) { split(\$i, a, ":"); umi = a[3] }
+            else if (\$i ~ /^cs:i:/) { split(\$i, a, ":"); umi_cluster_size = a[3] }
+            else if (\$i ~ /^su:i:/) { split(\$i, a, ":"); umi_read_count = a[3] }
+         }
+         if ( assign != "Assigned" || gene == "" || umi == "" || umi_read_count == "" ) next;
+         print \$1, gene, chr, cb, umi, umi_cluster_size, umi_read_count
+      }
+   ' \
+   > tab.tsv
+
+   rm filtered.bam
+
+   """
+}
+
+process counts_per_gene {
+
+   tag "${id}"
+
+   publishDir( 
+      "${params.outputs}/counts", 
+      mode: 'copy',
+      saveAs: { "${id}.${it}" },
+   )
+
+   input:
+   tuple val( id ), path( tabfile )
+
+   output:
+   tuple val( id ), path( "counts_per_gene.tsv" )
+
+   script:
+   """
+   #!/usr/bin/env python 
+
+   import pandas as pd
+
+   (
+      pd.read_csv("${tabfile}", sep="\\t")
+      .groupby(["chr", "gene_id"])
+      .agg({"umi": "nunique", "umi_read_count": "sum"})
+      .rename(columns={
+         "umi": "umi_count",
+         "umi_read_count": "read_count",
+      })
+      .to_csv("counts_per_gene.tsv", sep="\\t")
+   )
+
+   """
+}
+
+
+process counts_per_cell {
+
+   tag "${id}"
+
+   publishDir( 
+      "${params.outputs}/counts", 
+      mode: 'copy',
+      saveAs: { "${id}.${it}" },
+   )
+
+   input:
+   tuple val( id ), path( tabfile )
+
+   output:
+   tuple val( id ), path( "counts_per_cell.tsv" )
+
+   script:
+   """
+   #!/usr/bin/env python 
+
+   import pandas as pd
+
+   (
+      pd.read_csv("${tabfile}", sep="\\t")
+      .groupby("cell_barcode")
+      .agg({"umi": "nunique", "umi_read_count": "sum"})
+      .rename(columns={
+         "umi": "umi_count",
+         "umi_read_count": "read_count",
+      })
+      .to_csv("counts_per_cell.tsv", sep="\\t")
+   )
+
+   """
+}
+
+process counts_per_gene_per_cell {
+
+   tag "${id}"
+
+   publishDir( 
+      "${params.outputs}/counts", 
+      mode: 'copy',
+      saveAs: { "${id}.${it}" },
+   )
+
+   input:
+   tuple val( id ), path( tabfile )
+
+   output:
+   tuple val( id ), path( "counts_per_gene_per_cell.tsv" )
+
+   script:
+   """
+   #!/usr/bin/env python 
+
+   import pandas as pd
+
+   (
+      pd.read_csv("${tabfile}", sep="\\t")
+      .groupby(["chr", "gene_id", "cell_barcode"])
+      .agg({"umi": "nunique", "umi_read_count": "sum"})
+      .rename(columns={
+         "umi": "umi_count",
+         "umi_read_count": "read_count",
+      })
+      .to_csv("counts_per_gene_per_cell.tsv", sep="\\t")
+   )
+
+   """
+}
+
+
+// Count unique UMIs per cell per gene
+process UMItools_count_tab {
+
+   tag "${id}"
+
+   label 'big_mem'
+
+   publishDir( 
+      "${params.outputs}/counts", 
+      mode: 'copy',
+      saveAs: { "${id}-${it}" },
+   )
+
+   input:
+   tuple val( id ), path( tabfile )
+   val umi_method
+   val per_clone
+
+   output:
+   tuple val( id ), path( "${id}.umitools_count.tsv" ), emit: main
+   path "${id}.umitools_count.log", emit: logs
+
+   script:
+   """
+   export MPLCONFIGDIR=tmp
+   mkdir \$MPLCONFIGDIR
+
+   umi_tools count_tab \
+      --method ${umi_method} ${per_clone ? "--per-cell" : ""} \
+		--stdin "${tabfile}" \
+      --stdout umitools_count0.tsv \
+      --log "${id}.umitools_count.log"
+
+   awk -v OFS='\\t' -v id="${id}" '
+      BEGIN { print "sample_id", "guide_name", "umi_count" }
+      NR > 1 { \$1 = \$1; print id, \$0 }
+   ' umitools_count0.tsv \
+   > "${id}.umitools_count.tsv"
 
    """
 }
@@ -75,7 +296,7 @@ process UMItools_extract {
  */
 process UMItools_count {
 
-   tag "${sample_id}"
+   tag "${id}"
 
    // errorStrategy 'retry'
    // maxRetries 2
@@ -83,29 +304,31 @@ process UMItools_count {
    publishDir( 
       "${params.outputs}/counts", 
       mode: 'copy',
-      saveAs: { "${id}-${it}" }, 
+      // saveAs: { "${id}.${it}" }, 
    )
 
    input:
-   tuple val( sample_id ), path( bamfile )
+   tuple val( id ), path( bamfile )
    val paired
 
    output:
-   tuple val( sample_id ), path( "*.tsv" ), emit: main
-   path( "*.log" ), emit: logs
+   tuple val( id ), path( "*.umitools_count.tsv" ), emit: main
+   path "*.umitools_count.log", emit: logs
 
    script:
    """
-   samtools sort ${bamfile} -o ${bamfile.getBaseName()}.sorted.bam
-   samtools index ${bamfile.getBaseName()}.sorted.bam
+   samtools view -F1024 "${bamfile}" \
+   | samtools sort - -@ ${task.cpus} -m ${Math.round(task.memory.getGiga() * 0.8)}G -o sorted.bam
+   samtools index sorted.bam
    umi_tools count \
-		--per-gene ${paired ? '--paired --chimeric-pairs discard --unpaired-reads discard' : ''} \
+		--per-gene \
       --per-cell \
 		--gene-tag XT \
-      --log ${sample_id}.count.log \
-		--stdin ${bamfile.getBaseName()}.sorted.bam \
-      --stdout ${sample_id}.umitools_count.tsv \
-   && rm ${bamfile.getBaseName()}.sorted.bam
+      --assigned-status-tag XS ${paired ? '--paired --chimeric-pairs discard --unpaired-reads discard' : ''} \
+      --log ${id}.umitools_count.log \
+		--stdin sorted.bam \
+      --stdout ${id}.umitools_count.tsv \
+   && rm sorted.bam
 
    """
 }

--- a/modules/whitelisting.nf
+++ b/modules/whitelisting.nf
@@ -7,7 +7,7 @@ process build_whitelist {
       "${params.outputs}/barcodes", 
       mode: 'copy',
       pattern: "whitelist.txt.gz",
-      saveAs: { "${id}-${it}" },
+      saveAs: { "${id}.${it}" },
    )
 
    input:
@@ -81,7 +81,7 @@ process add_errors_to_whitelist {
       "${params.outputs}/barcodes", 
       mode: 'copy',
       pattern: "whitelist-err.txt.gz",
-      saveAs: { "${id}-${it}" },
+      saveAs: { "${id}.${it}" },
    )
 
    input:

--- a/modules/whitelisting.nf
+++ b/modules/whitelisting.nf
@@ -1,12 +1,12 @@
 // Build whitelist from provided barcode files
 process build_whitelist {
 
-   tag "${id}:rev ${reverse}"
+   tag "${id}:${reverse ? "rev ${reverse}" : ""}"
 
    publishDir( 
       "${params.outputs}/barcodes", 
       mode: 'copy',
-      pattern: "whitelist.txt",
+      pattern: "whitelist.txt.gz",
       saveAs: { "${id}-${it}" },
    )
 
@@ -15,11 +15,11 @@ process build_whitelist {
    val reverse
 
    output:
-   tuple val( id ), path( "whitelist.txt" )
+   tuple val( id ), path( "whitelist.txt.gz" )
 
    script:
    """
-   set -euox
+   set -euox pipefail
    BARCODES=(${bcs})
    for i in "\${!BARCODES[@]}"
    do
@@ -66,6 +66,8 @@ process build_whitelist {
    | awk -F, '{ print \$2\$3\$4 }' \
    > whitelist.txt
 
+   pigz -v -p ${task.cpus} whitelist.txt
+
    """
 }
 
@@ -78,7 +80,7 @@ process add_errors_to_whitelist {
    publishDir( 
       "${params.outputs}/barcodes", 
       mode: 'copy',
-      pattern: "whitelist.txt",
+      pattern: "whitelist-err.txt.gz",
       saveAs: { "${id}-${it}" },
    )
 
@@ -86,19 +88,20 @@ process add_errors_to_whitelist {
    tuple val( id ), path( whitelist )
 
    output:
-   tuple val( id ), path( "whitelist-err.txt" )
+   tuple val( id ), path( "whitelist-err.txt.gz" )
 
    script:
    """
    #!/usr/bin/env python
 
    from itertools import product
+   import gzip
 
    ALPHABET = "ATCGN"
    INPUT_FILE = "${whitelist}"
-   OUTPUT_FILE = "whitelist-err.txt"
+   OUTPUT_FILE = "whitelist-err.txt.gz"
 
-   with open(OUTPUT_FILE, 'w') as outfile, open(INPUT_FILE, 'r') as infile:
+   with gzip.open(OUTPUT_FILE, 'wt') as outfile, gzip.open(INPUT_FILE, 'rt') as infile:
       for line in infile:
          bc_length = len(line)
          break
@@ -119,6 +122,37 @@ process add_errors_to_whitelist {
       else:
          for line in infile:
             print(line.strip(), file=outfile)
+
+   """
+}
+
+
+process chunk_whitelist {
+
+   tag "${id}"
+   label "big_cpu"
+
+   // publishDir( 
+   //    "${params.outputs}/barcodes", 
+   //    mode: 'copy',
+   //    pattern: "whitelist.txt",
+   //    saveAs: { "${id}-${it}" },
+   // )
+
+   input:
+   tuple val( id ), path( whitelist )
+   val chunk_size
+
+   output:
+   tuple val( id ), path( "chunk_*.gz" )
+
+   script:
+   """
+   zcat "${whitelist}" | split -l "${chunk_size}" - chunk_
+   for f in chunk_*
+   do
+      pigz -v -p ${task.cpus} "\$f"
+   done
 
    """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,7 +30,7 @@ params {
 
     allow_cell_errors = true
     whitelist_chunk_size = 500000000  // 500million
-    mapper = "bowtie2"
+    mapper = "star"
 
     reverse = "" // which barcodes to reverse, of any
     unpaired = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,9 +3,9 @@ manifest {
     author          = "Eachan O. Johnson"
     homePage        = "https://github.com/scbirlab/nf-sbrnaseq"
     description     = "Process demultiplexed Illumina paired-end FASTQ files from multiple bacterial samples into a gene x cell count table"
-    defaultBranch   = "v0.0.11"
+    defaultBranch   = "v0.0.12"
     nextflowVersion = '!>=22.10.1'
-    version         = "0.0.11"
+    version         = "0.0.12"
     doi             = ''
 
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,6 +33,8 @@ params {
     mapper = "bowtie2"
 
     reverse = "" // which barcodes to reverse, of any
+    unpaired = false
+    nanopore = false
 
     // - Feature counting
     // * Strandedness: 1 for forward, 2 for reverse
@@ -95,9 +97,9 @@ profiles {
       executor = 'slurm'
       memory = 8.GB
       cpus = 1
+      time = '12h'
 
       withLabel: big_cpu {
-        time = '3h'
         cpus = 16
         memory = 16.GB
       }

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,6 +29,7 @@ params {
     min_length = "9:38" 
 
     allow_cell_errors = true
+    whitelist_chunk_size = 500000000  // 500million
     mapper = "bowtie2"
 
     reverse = "" // which barcodes to reverse, of any
@@ -92,6 +93,8 @@ profiles {
     process {
       
       executor = 'slurm'
+      memory = 8.GB
+      cpus = 1
 
       withLabel: big_cpu {
         time = '3h'


### PR DESCRIPTION
Improvements:
- Downloads from SRA are faster, now using `fasterq-dump`
- Additional assembly and taxon annotations from NCBI.

Fixes:
- UMIcollapse does not consider cell barcodes. Now an awk script tags the BAM reads with `CB:Z:<cell-barcode>` and prepends the UMI in the read name with the cell barcode before UMIcollapse. Afterwards, the original UMI is restored.
- Counting is now from the `cs` and `su` BAM tags from UMIcollapse, instead of using UMItools count.
- Counts from featureCounts are now called `pseudobulk_read_count` for clarity.